### PR TITLE
make module cache scanner nothrow (DCD/319)

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -116,12 +116,21 @@ struct ModuleCache
 			}
 			else
 			{
-				foreach (fileName; dirEntries(path, "*.{d,di}", SpanMode.depth))
+				void scanFrom(const string root)
 				{
-					if (fileName.baseName.startsWith(".#") || !fileName.isFile)
-						continue;
-					cacheModule(fileName);
+					try foreach (f; dirEntries(root, SpanMode.shallow))
+					{
+						if (f.name.isFile)
+						{
+							if (!f.name.extension.among(".d", ".di") || f.name.baseName.startsWith(".#"))
+								continue;
+							cacheModule(f.name);
+						}
+						else scanFrom(f.name);
+					}
+					catch(FileException) {}
 				}
+				scanFrom(path);
 			}
 		}
 	}


### PR DESCRIPTION
The problem is that inaccessible folders lead to a FileException when scanning directories recursively.
The fix consists into a manual recursive scanner + pokemon exception handling (for FileException only).