### PR TITLE
fix auto slices type deduction

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -1203,8 +1203,8 @@ class InitializerVisitor : ASTVisitor
 
 	override void visit(const IndexExpression index)
 	{
-		index.accept(this);
 		lookup.breadcrumbs.insert(ARRAY_SYMBOL_NAME);
+		index.accept(this);
 	}
 
 	override void visit(const Initializer initializer)
@@ -1216,8 +1216,8 @@ class InitializerVisitor : ASTVisitor
 
 	override void visit(const ArrayInitializer ai)
 	{
-		ai.accept(this);
 		lookup.breadcrumbs.insert(ARRAY_SYMBOL_NAME);
+		ai.accept(this);
 	}
 
 	// Skip these


### PR DESCRIPTION
My previous PR applied the fix in the wrong overload of visit.