### PR TITLE
fix for issue #32 - builtin constants in multithreaded app problem

### DIFF
--- a/src/dsymbol/builtin/names.d
+++ b/src/dsymbol/builtin/names.d
@@ -3,71 +3,71 @@ module dsymbol.builtin.names;
 import dparse.lexer;
 import dsymbol.string_interning;
 
-package immutable(istring[24]) builtinTypeNames;
+package const(istring[24]) builtinTypeNames;
 
 /// Constants for buit-in or dummy symbol names
-immutable istring FUNCTION_SYMBOL_NAME;
+const istring FUNCTION_SYMBOL_NAME;
 /// ditto
-immutable istring IMPORT_SYMBOL_NAME;
+const istring IMPORT_SYMBOL_NAME;
 /// ditto
-immutable istring ARRAY_SYMBOL_NAME;
+const istring ARRAY_SYMBOL_NAME;
 /// ditto
-immutable istring ASSOC_ARRAY_SYMBOL_NAME;
+const istring ASSOC_ARRAY_SYMBOL_NAME;
 /// ditto
-immutable istring POINTER_SYMBOL_NAME;
+const istring POINTER_SYMBOL_NAME;
 /// ditto
-immutable istring PARAMETERS_SYMBOL_NAME;
+const istring PARAMETERS_SYMBOL_NAME;
 /// ditto
-immutable istring WITH_SYMBOL_NAME;
+const istring WITH_SYMBOL_NAME;
 /// ditto
-immutable istring CONSTRUCTOR_SYMBOL_NAME;
+const istring CONSTRUCTOR_SYMBOL_NAME;
 /// ditto
-immutable istring DESTRUCTOR_SYMBOL_NAME;
+const istring DESTRUCTOR_SYMBOL_NAME;
 /// ditto
-immutable istring ARGPTR_SYMBOL_NAME;
+const istring ARGPTR_SYMBOL_NAME;
 /// ditto
-immutable istring ARGUMENTS_SYMBOL_NAME;
+const istring ARGUMENTS_SYMBOL_NAME;
 /// ditto
-immutable istring THIS_SYMBOL_NAME;
+const istring THIS_SYMBOL_NAME;
 /// ditto
-immutable istring SUPER_SYMBOL_NAME;
+const istring SUPER_SYMBOL_NAME;
 /// ditto
-immutable istring UNITTEST_SYMBOL_NAME;
+const istring UNITTEST_SYMBOL_NAME;
 /// ditto
-immutable istring DOUBLE_LITERAL_SYMBOL_NAME;
+const istring DOUBLE_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring FLOAT_LITERAL_SYMBOL_NAME;
+const istring FLOAT_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring IDOUBLE_LITERAL_SYMBOL_NAME;
+const istring IDOUBLE_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring IFLOAT_LITERAL_SYMBOL_NAME;
+const istring IFLOAT_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring INT_LITERAL_SYMBOL_NAME;
+const istring INT_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring LONG_LITERAL_SYMBOL_NAME;
+const istring LONG_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring REAL_LITERAL_SYMBOL_NAME;
+const istring REAL_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring IREAL_LITERAL_SYMBOL_NAME;
+const istring IREAL_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring UINT_LITERAL_SYMBOL_NAME;
+const istring UINT_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring ULONG_LITERAL_SYMBOL_NAME;
+const istring ULONG_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring CHAR_LITERAL_SYMBOL_NAME;
+const istring CHAR_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring DSTRING_LITERAL_SYMBOL_NAME;
+const istring DSTRING_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring STRING_LITERAL_SYMBOL_NAME;
+const istring STRING_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring WSTRING_LITERAL_SYMBOL_NAME;
+const istring WSTRING_LITERAL_SYMBOL_NAME;
 /// ditto
-immutable istring BOOL_VALUE_SYMBOL_NAME;
+const istring BOOL_VALUE_SYMBOL_NAME;
 
 /**
  * Translates the IDs for built-in types into an interned string.
  */
-istring getBuiltinTypeName(IdType id) nothrow pure @nogc @safe
+istring getBuiltinTypeName(IdType id) nothrow @nogc @safe
 {
 	switch (id)
 	{

--- a/src/dsymbol/builtin/names.d
+++ b/src/dsymbol/builtin/names.d
@@ -3,66 +3,66 @@ module dsymbol.builtin.names;
 import dparse.lexer;
 import dsymbol.string_interning;
 
-package const(istring[24]) builtinTypeNames;
+package istring[24] builtinTypeNames;
 
 /// Constants for buit-in or dummy symbol names
-const istring FUNCTION_SYMBOL_NAME;
+istring FUNCTION_SYMBOL_NAME;
 /// ditto
-const istring IMPORT_SYMBOL_NAME;
+istring IMPORT_SYMBOL_NAME;
 /// ditto
-const istring ARRAY_SYMBOL_NAME;
+istring ARRAY_SYMBOL_NAME;
 /// ditto
-const istring ASSOC_ARRAY_SYMBOL_NAME;
+istring ASSOC_ARRAY_SYMBOL_NAME;
 /// ditto
-const istring POINTER_SYMBOL_NAME;
+istring POINTER_SYMBOL_NAME;
 /// ditto
-const istring PARAMETERS_SYMBOL_NAME;
+istring PARAMETERS_SYMBOL_NAME;
 /// ditto
-const istring WITH_SYMBOL_NAME;
+istring WITH_SYMBOL_NAME;
 /// ditto
-const istring CONSTRUCTOR_SYMBOL_NAME;
+istring CONSTRUCTOR_SYMBOL_NAME;
 /// ditto
-const istring DESTRUCTOR_SYMBOL_NAME;
+istring DESTRUCTOR_SYMBOL_NAME;
 /// ditto
-const istring ARGPTR_SYMBOL_NAME;
+istring ARGPTR_SYMBOL_NAME;
 /// ditto
-const istring ARGUMENTS_SYMBOL_NAME;
+istring ARGUMENTS_SYMBOL_NAME;
 /// ditto
-const istring THIS_SYMBOL_NAME;
+istring THIS_SYMBOL_NAME;
 /// ditto
-const istring SUPER_SYMBOL_NAME;
+istring SUPER_SYMBOL_NAME;
 /// ditto
-const istring UNITTEST_SYMBOL_NAME;
+istring UNITTEST_SYMBOL_NAME;
 /// ditto
-const istring DOUBLE_LITERAL_SYMBOL_NAME;
+istring DOUBLE_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring FLOAT_LITERAL_SYMBOL_NAME;
+istring FLOAT_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring IDOUBLE_LITERAL_SYMBOL_NAME;
+istring IDOUBLE_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring IFLOAT_LITERAL_SYMBOL_NAME;
+istring IFLOAT_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring INT_LITERAL_SYMBOL_NAME;
+istring INT_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring LONG_LITERAL_SYMBOL_NAME;
+istring LONG_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring REAL_LITERAL_SYMBOL_NAME;
+istring REAL_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring IREAL_LITERAL_SYMBOL_NAME;
+istring IREAL_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring UINT_LITERAL_SYMBOL_NAME;
+istring UINT_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring ULONG_LITERAL_SYMBOL_NAME;
+istring ULONG_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring CHAR_LITERAL_SYMBOL_NAME;
+istring CHAR_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring DSTRING_LITERAL_SYMBOL_NAME;
+istring DSTRING_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring STRING_LITERAL_SYMBOL_NAME;
+istring STRING_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring WSTRING_LITERAL_SYMBOL_NAME;
+istring WSTRING_LITERAL_SYMBOL_NAME;
 /// ditto
-const istring BOOL_VALUE_SYMBOL_NAME;
+istring BOOL_VALUE_SYMBOL_NAME;
 
 /**
  * Translates the IDs for built-in types into an interned string.

--- a/src/dsymbol/conversion/second.d
+++ b/src/dsymbol/conversion/second.d
@@ -329,7 +329,7 @@ void resolveInheritance(DSymbol* symbol, ref UnrolledList!(TypeLookup*, Mallocat
 			baseClass = symbols[0];
 		}
 
-		static bool shouldSkipFromBase(const DSymbol* d) pure nothrow @nogc
+		static bool shouldSkipFromBase(const DSymbol* d) nothrow @nogc
 		{
 			if (d.name.ptr == CONSTRUCTOR_SYMBOL_NAME.ptr)
 				return false;


### PR DESCRIPTION
Builtin constants are marked as immutable but initialized as thread locals.
This causes problems when there are several threads in application.
See #32 for details.