### PR TITLE
dsymbol.modulecache: Skip directories containing .no-dcd files

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -118,6 +118,9 @@ struct ModuleCache
 			{
 				void scanFrom(const string root)
 				{
+					if (exists(buildPath(root, ".no-dcd")))
+						return;
+
 					try foreach (f; dirEntries(root, SpanMode.shallow))
 					{
 						if (f.name.isFile)


### PR DESCRIPTION
Needed for https://github.com/dlang-community/DCD/issues/340.