### PR TITLE
scanner, fix possible null string after consumed by range (with 2.080)

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -101,12 +101,11 @@ struct ModuleCache
 
 		auto newPaths = paths
 			.map!(a => absolutePath(expandTilde(a)))
-			.filter!(a => existanceCheck(a) && !importPaths[].canFind(a))
-			.map!(internString)
-			.array;
-		importPaths.insert(newPaths);
+			.filter!(a => existanceCheck(a) && !importPaths[].canFind(a));
 
-		foreach (path; newPaths[])
+		importPaths.insert(newPaths.save.map!(internString).array);
+
+		foreach (path; newPaths)
 		{
 			if (path.isFile)
 			{


### PR DESCRIPTION
Looks like a regression in 2.080 or to the opposite a bug revealed. Whatever it is, DCD needs this for now.