### PR TITLE
Disable appveyor with nightly, since it uses a too old DMD (2075)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
 platform: x64
 environment:
  matrix:
-  - DC: dmd
-    DVersion: nightly
-    arch: x64
-  - DC: dmd
-    DVersion: nightly
-    arch: x86
+  #- DC: dmd
+  #  DVersion: nightly
+  #  arch: x64
+  #- DC: dmd
+  #  DVersion: nightly
+  #  arch: x86
   - DC: dmd
     DVersion: beta
     arch: x64


### PR DESCRIPTION
Appveyor downloads 2.075 which is too old for the most recent EMSI containers because they use `do` for contracts.