### PR TITLE
fix #77 - Crash due to #74

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -604,7 +604,7 @@ final class FirstPass : ASTVisitor
 
 	override void visit(const IfStatement ifs)
 	{
-		if (ifs.identifier != tok!"")
+		if (ifs.identifier != tok!"" && ifs.thenStatement)
 		{
 			pushScope(ifs.thenStatement.startLocation, ifs.thenStatement.endLocation);
 			scope(exit) popScope();


### PR DESCRIPTION
dparse can return incomplete `IfStatement`s to make DCD better.