### PR TITLE
fix #76 - Revert "scanner, fix possible null string after consumed by…

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -101,11 +101,12 @@ struct ModuleCache
 
 		auto newPaths = paths
 			.map!(a => absolutePath(expandTilde(a)))
-			.filter!(a => existanceCheck(a) && !importPaths[].canFind(a));
+			.filter!(a => existanceCheck(a) && !importPaths[].canFind(a))
+			.map!(internString)
+			.array;
+		importPaths.insert(newPaths);
 
-		importPaths.insert(newPaths.save.map!(internString).array);
-
-		foreach (path; newPaths)
+		foreach (path; newPaths[])
 		{
 			if (path.isFile)
 			{


### PR DESCRIPTION
… range (with 2.080)"

This reverts commit 88da3b42eb4e32505b4dfaa19c537d5f652d1656.

___

This fixes the regression but under win32, DCD built with DMD32 needs to be piped, otherwise some strange messages about _connection refused_ appear (which already happended in the past BTW, with std.stdio source). At least there's no freeze anymore when scanning the imports (because recent work on EMSI containers fixed some stuff too).