### PR TITLE
fix #85 - Add support for expression-based contracts

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
 	"license": "BSL-1.0",
 	"authors": ["Brian Schott"],
 	"dependencies": {
-		"libdparse": "~>0.8.5",
+		"libdparse": "~>0.9.0",
 		"emsi_containers": "~>0.8.0-alpha.7",
 		"stdx-allocator": "~>2.77.0"
 	}

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -746,8 +746,8 @@ private:
 		import std.algorithm : max;
 
 		immutable scopeEnd = max(
-			functionBody.inStatement is null ? 0 : functionBody.inStatement.blockStatement.endLocation,
-			functionBody.outStatement is null ? 0 : functionBody.outStatement.blockStatement.endLocation,
+			functionBody.inStatements.length == 0 ? 0 : functionBody.inStatements[$-1].blockStatement.endLocation,
+			functionBody.outStatements.length == 0 ? 0 : functionBody.outStatements[$-1].blockStatement.endLocation,
 			functionBody.blockStatement is null ? 0 : functionBody.blockStatement.endLocation,
 			functionBody.bodyStatement is null ? 0 : functionBody.bodyStatement.blockStatement.endLocation);
 		Scope* s = semanticAllocator.make!Scope(cast(uint) scopeBegin, cast(uint) scopeEnd);


### PR DESCRIPTION
good thing that max() was already used :sweat_smile: 