### PR TITLE
Fix potential memory leak

### DIFF
--- a/src/dsymbol/conversion/second.d
+++ b/src/dsymbol/conversion/second.d
@@ -444,6 +444,7 @@ void resolveTypeFromInitializer(DSymbol* symbol, TypeLookup* lookup,
 				{
 					lastSuffix = cache.symbolAllocator.make!(DSymbol)(a, CompletionKind.dummy, lastSuffix);
 					lastSuffix.qualifier = SymbolQualifier.array;
+					lastSuffix.ownType = true;
 
 					if (suffix is null)
 						suffix = lastSuffix;


### PR DESCRIPTION
While looking around because of #81, I found that some `DSymbol`'s don't seem to be ever freed: the `lastSuffix`'s created during the loop (apart from the last one) are types that are not owned by any other `DSymbol` instance, and will probably never get freed.
Maybe I'm wrong on this, I've never touched this code before; but it looks quite fishy to me.