### PR TITLE
Implement cache clearing facilities

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -78,14 +78,7 @@ struct ModuleCache
 
 	~this()
 	{
-		foreach (entry; ModuleCache.cache[])
-			Mallocator.instance.dispose(entry);
-		foreach (symbol; deferredSymbols[])
-			Mallocator.instance.dispose(symbol);
-
-		// TODO: This call to deallocateAll is a workaround for issues of
-		// CAllocatorImpl and GCAllocator not interacting well.
-		symbolAllocator.deallocateAll();
+		clear();
 	}
 
 	/**
@@ -138,10 +131,22 @@ struct ModuleCache
 		}
 	}
 
-	/// TODO: Implement
+	/**
+	 * Clears the cache from all import paths
+	 */
 	void clear()
 	{
-		info("ModuleCache.clear is not yet implemented.");
+		foreach (entry; cache[])
+			Mallocator.instance.dispose(entry);
+		foreach (symbol; deferredSymbols[])
+			Mallocator.instance.dispose(symbol);
+
+		// TODO: This call to deallocateAll is a workaround for issues of
+		// CAllocatorImpl and GCAllocator not interacting well.
+		symbolAllocator.deallocateAll();
+		cache.clear();
+		deferredSymbols.clear();
+		importPaths.clear();
 	}
 
 	/**

--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -132,6 +132,39 @@ struct ModuleCache
 	}
 
 	/**
+	 * Removes the given paths from the list of directories checked for
+	 * imports. Corresponding cache entries are removed.
+	 */
+	void removeImportPaths(const string[] paths)
+	{
+		foreach (path; paths[])
+		{
+			if (!importPaths[].canFind(path))
+			{
+				warning("Cannot remove ", path, " because it is not imported");
+				continue;
+			}
+
+			importPaths.remove(path);
+
+			foreach (cacheEntry; cache[])
+			{
+				if (cacheEntry.path.startsWith(path))
+				{
+					foreach (deferredSymbol; deferredSymbols[].find!(d => d.symbol.symbolFile.startsWith(cacheEntry.path)))
+					{
+						deferredSymbols.remove(deferredSymbol);
+						Mallocator.instance.dispose(deferredSymbol);
+					}
+
+					cache.remove(cacheEntry);
+					Mallocator.instance.dispose(cacheEntry);
+				}
+			}
+		}
+	}
+
+	/**
 	 * Clears the cache from all import paths
 	 */
 	void clear()

--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -82,7 +82,7 @@ struct ModuleCache
 	}
 
 	/**
-	 * Adds the given path to the list of directories checked for imports.
+	 * Adds the given paths to the list of directories checked for imports.
 	 * Performs duplicate checking, so multiple instances of the same path will
 	 * not be present.
 	 */


### PR DESCRIPTION
This PR would introduce two changes (and a small typo fix):

**The first:**
Implementing `ModuleCache.clear()`: from what I see, it looks like `~this()` already had almost all it needed. I simply moved the code over, added a proper `.clear()` call for `cache`, `deferredSymbols` and `importPaths`, and called `clear()` from `~this()`.

**The second:**
Adding `ModuleCache.removeImportPaths(string[] paths)`: this can be useful in several cases. For example, in Atom and VSCode, a user can have multiple folders open at the same time; and when they close one of them, clearing symbols from that folder would make sense.

Right now, listing all symbols from all folders will still show symbols from the folder that has just been removed, imports from removed dependencies will still be shown, etc. This can also help with memory usage, as the only way (as far as I can tell) to free anything in the cache is to destroy it and create another one.