### PR TITLE
Skip over specified function bodies

### DIFF
--- a/src/dsymbol/conversion/package.d
+++ b/src/dsymbol/conversion/package.d
@@ -143,14 +143,12 @@ class SimpleParser : Parser
 		return null;
 	}
 
-	override FunctionBody parseFunctionBody()
+	override SpecifiedFunctionBody parseSpecifiedFunctionBody()
 	{
 		bool needDo;
-		// no impl
-		if (currentIs(tok!";"))
-			advance();
+
 		// no contracts
-		else if (currentIs(tok!"{"))
+		if (currentIs(tok!"{"))
 			skipBraces();
 		// skip contracts
 		else while (true)
@@ -188,7 +186,7 @@ class SimpleParser : Parser
 		// body
 		if (currentIs(tok!"{"))
 			skipBraces();
-		return allocator.make!FunctionBody();
+		return allocator.make!SpecifiedFunctionBody;
 	}
 }
 

--- a/src/dsymbol/conversion/package.d
+++ b/src/dsymbol/conversion/package.d
@@ -143,6 +143,16 @@ class SimpleParser : Parser
 		return null;
 	}
 
+	override MissingFunctionBody parseMissingFunctionBody()
+	{
+		skipContracts();
+		if (moreTokens && (currentIs(tok!"do") || current.text == "body"))
+			return null;
+		if (currentIs(tok!";"))
+			advance();
+		return allocator.make!MissingFunctionBody;
+	}
+
 	override SpecifiedFunctionBody parseSpecifiedFunctionBody()
 	{
 		bool needDo;
@@ -151,7 +161,20 @@ class SimpleParser : Parser
 		if (currentIs(tok!"{"))
 			skipBraces();
 		// skip contracts
-		else while (true)
+		else needDo = skipContracts();
+		if (needDo && !currentIs(tok!"{"))
+			advance();
+		// body
+		if (currentIs(tok!"{"))
+			skipBraces();
+		return allocator.make!SpecifiedFunctionBody;
+	}
+
+	private bool skipContracts()
+	{
+		bool needDo;
+
+		while (true)
 		{
 			if (currentIs(tok!"in"))
 			{
@@ -181,12 +204,8 @@ class SimpleParser : Parser
 			}
 			else break;
 		}
-		if (needDo && !currentIs(tok!"{"))
-			advance();
-		// body
-		if (currentIs(tok!"{"))
-			skipBraces();
-		return allocator.make!SpecifiedFunctionBody;
+
+		return needDo;
 	}
 }
 


### PR DESCRIPTION
From [what is said in libdparse](https://github.com/dlang-community/libdparse/blob/b3a6f843457bedebc929a7fcb85529f397c73ad3/src/dparse/parser.d#L3093), `SimpleParser` needs to be updated whenever `parseFunctionBody()` is changed in libdparse.
With the changes of DIP1009, I think it needs to override `parseSpecifiedFunctionBody()` instead, as function literals and delegates now have a `SpecifiedFunctionBody` instead of a `FunctionBody`.