### PR TITLE
do not use `hashOf` for now because it's not `@safe` and breaks DCD

### DIFF
--- a/src/dsymbol/string_interning.d
+++ b/src/dsymbol/string_interning.d
@@ -46,8 +46,7 @@ private struct InternedString
 
 	size_t toHash() const nothrow @safe
 	{
-		import core.internal.hash : hashOf;
-		return hashOf(data);
+		return typeid(string).getHash(&data);
 	}
 
 	string data;


### PR DESCRIPTION
The error appeared when addapting DCD to dparse 0.10.4. older compilers fail to compile because hashOf in this case is only safe from DMDFE 2.083.

See [(previous) GH release building log](https://travis-ci.org/dlang-community/DCD/jobs/451289735#L529).