### PR TITLE
Reduce the number of parallel compilations in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   export PATH=$PATH:$PWD/.ntmp
 
 script:
-  - meson build && ninja -j8 -C build
-  - ninja -j8 -C build test -v
+  - meson build && ninja -j2 -C build
+  - ninja -j2 -C build test -v
   - dub build --build=release --compiler=${DC}
   - dub test --compiler=${DC}


### PR DESCRIPTION
[Travis machines only have 2 cores anyway](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system), so allowing ninja to start up to 8 processes at the same time doesn't increases the compilation speed, and leads to atrocious memory usage that has made builds fail recently.
Ninja auto-detects the number of processors a machine has, so by not telling it how many processes to launch it will uses the 2 cores automatically.