### PR TITLE
solve template type parameters that implicitly converts to something

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -913,6 +913,11 @@ private:
 					name = p.templateTypeParameter.identifier.text;
 					kind = CompletionKind.aliasName;
 					index = p.templateTypeParameter.identifier.index;
+					// even if templates are not solved we can get the completions
+					// for the type the template parameter implicitly converts to,
+					// which is often useful for aggregate types.
+					if (p.templateTypeParameter.colonType)
+						type = p.templateTypeParameter.colonType;
 				}
 				else if (p.templateValueParameter !is null)
 				{
@@ -929,6 +934,8 @@ private:
 					addTypeToLookups(templateParameter.typeLookups, type);
 				templateParameter.parent = symbol;
 				symbol.addChild(templateParameter, true);
+				if (currentScope)
+					currentScope.addSymbol(templateParameter.acSymbol, false);
 			}
 		}
 	}

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -153,6 +153,22 @@ unittest
 	assert(scopeB.getSymbolsByName(SUPER_SYMBOL_NAME)[0].type is A);
 }
 
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+
+	writeln("Running template type parameters tests...");
+	auto source = q{ struct Foo(T : int){} struct Bar(T : Foo){} };
+	auto pair = generateAutocompleteTrees(source, "", 0, cache);
+	DSymbol* T1 = pair.symbol.getFirstPartNamed(internString("Foo"));
+	DSymbol* T2 = T1.getFirstPartNamed(internString("T"));
+	assert(T2.type.name == "int");
+	DSymbol* T3 = pair.symbol.getFirstPartNamed(internString("Bar"));
+	DSymbol* T4 = T3.getFirstPartNamed(internString("T"));
+	assert(T4.type);
+	assert(T4.type == T1);
+}
+
 static StringCache stringCache = void;
 static this()
 {


### PR DESCRIPTION
Template value parameters didn't work because the acSymbol was not put in the scope. Easy fix (#108).
Otherwise add the code so that a TemplateTypeParameter that must implicitly convert to a type get at least the base type completions. (#106)