### PR TITLE
Implement special ditto documentation handling

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -1238,7 +1238,7 @@ auto byIdentifier(const TypeIdentifierPart tip) pure nothrow @trusted
 	return range;
 }
 
-bool isDitto(in char[] comment)
+bool isDitto(scope const(char)[] comment)
 {
 	import std.uni : icmp;
 

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -371,7 +371,7 @@ public:
 	/**
 	 * Documentation for the symbol.
 	 */
-	istring doc;
+	DocString doc;
 
 	/**
 	 * The symbol that represents the type.
@@ -422,6 +422,30 @@ public:
 		ubyte, "", 5));
 	// dfmt on
 
+}
+
+/**
+ * istring with actual content and information if it was ditto
+ */
+struct DocString
+{
+	/// creates a non-ditto comment
+	this(istring content)
+	{
+		this.content = content;
+	}
+
+	/// creates a comment which may have been ditto
+	this(istring content, bool ditto)
+	{
+		this.content = content;
+		this.ditto = ditto;
+	}
+
+	alias content this;
+
+	istring content;
+	bool ditto;
 }
 
 struct UpdatePair

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -429,13 +429,13 @@ public:
  */
 struct DocString
 {
-	/// creates a non-ditto comment
+	/// Creates a non-ditto comment.
 	this(istring content)
 	{
 		this.content = content;
 	}
 
-	/// creates a comment which may have been ditto
+	/// Creates a comment which may have been ditto, but has been resolved.
 	this(istring content, bool ditto)
 	{
 		this.content = content;
@@ -444,7 +444,9 @@ struct DocString
 
 	alias content this;
 
+	/// Contains the documentation string associated with this symbol, resolves ditto to the previous comment with correct scope.
 	istring content;
+	/// `true` if the documentation was just a "ditto" comment copying from the previous comment.
 	bool ditto;
 }
 


### PR DESCRIPTION
Stores ditto documentation using their actual documentation and has a special ditto flag on the documentation strings.

This is not backwards compatible with any code relying on documentation being "ditto" instead of the actual documentation, otherwise it's backwards compatible.