### PR TITLE
dsymbol.symbol: Fix segmentation fault when querying empty symbol list

### DIFF
--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -247,6 +247,8 @@ public:
 	{
 		import std.algorithm.iteration : filter;
 
+		if (&this is null)
+			return;
 		if (visited.contains(cast(size_t) &this))
 			return;
 		visited.insert(cast(size_t) &this);


### PR DESCRIPTION
This fixes handling of getting completions from empty modules.