### PR TITLE
Improve handling of array literals

### DIFF
--- a/src/dsymbol/builtin/names.d
+++ b/src/dsymbol/builtin/names.d
@@ -12,6 +12,8 @@ istring IMPORT_SYMBOL_NAME;
 /// ditto
 istring ARRAY_SYMBOL_NAME;
 /// ditto
+istring ARRAY_LITERAL_SYMBOL_NAME;
+/// ditto
 istring ASSOC_ARRAY_SYMBOL_NAME;
 /// ditto
 istring POINTER_SYMBOL_NAME;
@@ -133,6 +135,7 @@ static this()
 	FUNCTION_SYMBOL_NAME = internString("function");
 	IMPORT_SYMBOL_NAME = internString("import");
 	ARRAY_SYMBOL_NAME = internString("*arr*");
+	ARRAY_LITERAL_SYMBOL_NAME = internString("*arr-literal*");
 	ASSOC_ARRAY_SYMBOL_NAME = internString("*aa*");
 	POINTER_SYMBOL_NAME = internString("*");
 	PARAMETERS_SYMBOL_NAME = internString("*parameters*");

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -1407,8 +1407,19 @@ class InitializerVisitor : ASTVisitor
 
 	override void visit(const ArrayInitializer ai)
 	{
-		lookup.breadcrumbs.insert(ARRAY_SYMBOL_NAME);
-		ai.accept(this);
+		// If the array has any elements, assume all elements have the
+		// same type as the first element.
+		if (ai.arrayMemberInitializations.length)
+			ai.arrayMemberInitializations[0].accept(this);
+		lookup.breadcrumbs.insert(ARRAY_LITERAL_SYMBOL_NAME);
+	}
+
+	override void visit(const ArrayLiteral al)
+	{
+		// ditto
+		if (al.argumentList.items.length)
+			al.argumentList.items[0].accept(this);
+		lookup.breadcrumbs.insert(ARRAY_LITERAL_SYMBOL_NAME);
 	}
 
 	// Skip these

--- a/src/dsymbol/conversion/second.d
+++ b/src/dsymbol/conversion/second.d
@@ -442,53 +442,15 @@ void resolveTypeFromInitializer(DSymbol* symbol, TypeLookup* lookup,
 			currentSymbol = moduleScope.getFirstSymbolByNameAndCursor(
 				symbolNameToTypeName(crumb), symbol.location);
 
-			// solves auto arrays
-			if (crumb == ARRAY_SYMBOL_NAME)
-			{
-				auto nestedArr = crumbs.save();
-				auto a = nestedArr.front();
-
-				DSymbol* suffix;
-				DSymbol* lastSuffix;
-
-				// process the flags set in ArrayInitializer visit
-				while (true)
-				{
-					lastSuffix = cache.symbolAllocator.make!(DSymbol)(a, CompletionKind.dummy, lastSuffix);
-					lastSuffix.qualifier = SymbolQualifier.array;
-					lastSuffix.ownType = true;
-
-					if (suffix is null)
-						suffix = lastSuffix;
-
-					nestedArr.popFront();
-					if (nestedArr.empty())
-						break;
-					a = nestedArr.front();
-					if (a != ARRAY_SYMBOL_NAME)
-						break;
-				}
-
-				// last crumb should be the element type
-				DSymbol* elemType;
-				if (!nestedArr.empty)
-				{
-					suffix.addChildren(arraySymbols[], false);
-					elemType = moduleScope.getFirstSymbolByNameAndCursor(
-						symbolNameToTypeName(a), symbol.location);
-				}
-
-				// put the elem type to the back of the *arr* chain
-				if (suffix !is null && elemType)
-				{
-					suffix.type = elemType;
-					suffix.ownType = false;
-					symbol.type = lastSuffix;
-					symbol.ownType = true;
-				}
-			}
 			if (currentSymbol is null)
 				return;
+		}
+		else
+		if (crumb == ARRAY_LITERAL_SYMBOL_NAME)
+		{
+			auto arr = cache.symbolAllocator.make!(DSymbol)(ARRAY_LITERAL_SYMBOL_NAME, CompletionKind.dummy, currentSymbol);
+			arr.qualifier = SymbolQualifier.array;
+			currentSymbol = arr;
 		}
 		else if (crumb == ARRAY_SYMBOL_NAME)
 		{

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -63,9 +63,9 @@ void expectSymbolsAndTypes(const string source, const string[][] results,
 	q{bool b; int i;}.expectSymbolsAndTypes([["b", "bool"],["i", "int"]]);
 	q{auto b = false;}.expectSymbolsAndTypes([["b", "bool"]]);
 	q{auto b = true;}.expectSymbolsAndTypes([["b", "bool"]]);
-	q{auto b = [0];}.expectSymbolsAndTypes([["b", "*arr*", "int"]]);
-	q{auto b = [[0]];}.expectSymbolsAndTypes([["b", "*arr*", "*arr*", "int"]]);
-	q{auto b = [[[0]]];}.expectSymbolsAndTypes([["b", "*arr*", "*arr*", "*arr*", "int"]]);
+	q{auto b = [0];}.expectSymbolsAndTypes([["b", "*arr-literal*", "int"]]);
+	q{auto b = [[0]];}.expectSymbolsAndTypes([["b", "*arr-literal*", "*arr-literal*", "int"]]);
+	q{auto b = [[[0]]];}.expectSymbolsAndTypes([["b", "*arr-literal*", "*arr-literal*", "*arr-literal*", "int"]]);
 	//q{int* b;}.expectSymbolsAndTypes([["b", "*", "int"]]);
 	//q{int*[] b;}.expectSymbolsAndTypes([["b", "*arr*", "*", "int"]]);
 
@@ -164,6 +164,14 @@ unittest
 		assert(S);
 		assert(b.type.name == ARRAY_SYMBOL_NAME);
 		assert(b.type.type is S);
+	}
+	{
+		auto source = q{struct S{}; S s; auto b = [s][0];};
+		auto pair = generateAutocompleteTrees(source, cache);
+		DSymbol* S = pair.symbol.getFirstPartNamed(internString("S"));
+		DSymbol* b = pair.symbol.getFirstPartNamed(internString("b"));
+		assert(S);
+		assert(b.type is S);
 	}
 }
 


### PR DESCRIPTION
Note array literal construction a postfix operation in the breadcrumb chain, greatly simplifying its handling.