### PR TITLE
fix insertion of bad lookups due to new anon class expr

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -188,8 +188,18 @@ final class FirstPass : ASTVisitor
 		visitAggregateDeclaration(dec, CompletionKind.structName);
 	}
 
+	override void visit(const NewAnonClassExpression nace)
+	{
+		// its base classes would be added as "inherit" breadcrumbs in the current symbol
+		skipBaseClassesOfNewAnon = true;
+		nace.accept(this);
+		skipBaseClassesOfNewAnon = false;
+	}
+
 	override void visit(const BaseClass bc)
 	{
+		if (skipBaseClassesOfNewAnon)
+			return;
 		if (bc.type2.typeIdentifierPart is null ||
 			bc.type2.typeIdentifierPart.identifierOrTemplateInstance is null)
 			return;
@@ -1127,6 +1137,7 @@ private:
 	ModuleCache* cache;
 
 	bool includeParameterSymbols;
+	bool skipBaseClassesOfNewAnon;
 
 	ubyte foreachTypeIndexOfInterest;
 	ubyte foreachTypeIndex;

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -83,6 +83,14 @@ unittest
 	auto pair = generateAutocompleteTrees(source, cache);
 }
 
+// https://github.com/dlang-community/D-Scanner/issues/749
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+	auto source = q{ void test() { foo(new class A {});}  };
+	auto pair = generateAutocompleteTrees(source, cache);
+}
+
 unittest
 {
 	ModuleCache cache = ModuleCache(theAllocator);


### PR DESCRIPTION
This will fix https://github.com/dlang-community/D-Scanner/issues/749 and possible DCD crash when compiled with assertions on.