### PR TITLE
fix wrong aliasName breadcrumb inserted when bad code causes messed scopes

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
 	"license": "BSL-1.0",
 	"authors": ["Brian Schott"],
 	"dependencies": {
-		"libdparse": "~>0.11.0",
+		"libdparse": "~>0.11.3",
 		"emsi_containers": "0.8.0-alpha.11",
 		"stdx-allocator": "~>2.77.5"
 	}

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -294,6 +294,12 @@ final class FirstPass : ASTVisitor
 
 	override void visit(const AliasThisDeclaration dec)
 	{
+		const k = currentSymbol.acSymbol.kind;
+		if (k != CompletionKind.structName && k != CompletionKind.className &&
+			k != CompletionKind.unionName && k != CompletionKind.mixinTemplateName)
+		{
+			return;
+		}
 		currentSymbol.typeLookups.insert(Mallocator.instance.make!TypeLookup(
 			internString(dec.identifier.text), TypeLookupKind.aliasThis));
 	}

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -91,6 +91,14 @@ unittest
 	auto pair = generateAutocompleteTrees(source, cache);
 }
 
+// https://github.com/dlang-community/D-Scanner/issues/738
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+	auto source = q{ void b() { c = } alias b this;  };
+	auto pair = generateAutocompleteTrees(source, cache);
+}
+
 unittest
 {
 	ModuleCache cache = ModuleCache(theAllocator);


### PR DESCRIPTION
This will fix, (but not yet please dear GH) https://github.com/dlang-community/D-Scanner/issues/738