### PR TITLE
fix #130 - empty array literals are not solved as `void[]`

### DIFF
--- a/src/dsymbol/builtin/names.d
+++ b/src/dsymbol/builtin/names.d
@@ -65,6 +65,8 @@ istring STRING_LITERAL_SYMBOL_NAME;
 istring WSTRING_LITERAL_SYMBOL_NAME;
 /// ditto
 istring BOOL_VALUE_SYMBOL_NAME;
+/// ditto
+istring VOID_SYMBOL_NAME;
 
 /**
  * Translates the IDs for built-in types into an interned string.
@@ -162,6 +164,7 @@ static this()
 	STRING_LITERAL_SYMBOL_NAME = internString("*string");
 	WSTRING_LITERAL_SYMBOL_NAME = internString("*wstring");
 	BOOL_VALUE_SYMBOL_NAME = internString("*bool");
+	VOID_SYMBOL_NAME = internString("*void");
 }
 
 istring symbolNameToTypeName(istring name)
@@ -196,5 +199,7 @@ istring symbolNameToTypeName(istring name)
 		return internString("wstring");
 	if (name.ptr == BOOL_VALUE_SYMBOL_NAME.ptr)
 		return internString("bool");
+	if (name.ptr == VOID_SYMBOL_NAME.ptr)
+		return internString("void");
 	return name;
 }

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -1405,16 +1405,27 @@ class InitializerVisitor : ASTVisitor
 	{
 		// If the array has any elements, assume all elements have the
 		// same type as the first element.
-		if (ai.arrayMemberInitializations && ai.arrayMemberInitializations.length)
-			ai.arrayMemberInitializations[0].accept(this);
+		if (ai.arrayMemberInitializations)
+		{
+			if (ai.arrayMemberInitializations.length)
+				ai.arrayMemberInitializations[0].accept(this);
+			else
+				lookup.breadcrumbs.insert(VOID_SYMBOL_NAME);
+
+		}
 		lookup.breadcrumbs.insert(ARRAY_LITERAL_SYMBOL_NAME);
 	}
 
 	override void visit(const ArrayLiteral al)
 	{
 		// ditto
-		if (al.argumentList && al.argumentList.items.length)
-			al.argumentList.items[0].accept(this);
+		if (al.argumentList)
+		{
+			if (al.argumentList.items.length)
+				al.argumentList.items[0].accept(this);
+			else
+				lookup.breadcrumbs.insert(VOID_SYMBOL_NAME);
+		}
 		lookup.breadcrumbs.insert(ARRAY_LITERAL_SYMBOL_NAME);
 	}
 

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -66,6 +66,8 @@ void expectSymbolsAndTypes(const string source, const string[][] results,
 	q{auto b = [0];}.expectSymbolsAndTypes([["b", "*arr-literal*", "int"]]);
 	q{auto b = [[0]];}.expectSymbolsAndTypes([["b", "*arr-literal*", "*arr-literal*", "int"]]);
 	q{auto b = [[[0]]];}.expectSymbolsAndTypes([["b", "*arr-literal*", "*arr-literal*", "*arr-literal*", "int"]]);
+	q{auto b = [];}.expectSymbolsAndTypes([["b", "*arr-literal*", "void"]]);
+	q{auto b = [[]];}.expectSymbolsAndTypes([["b", "*arr-literal*", "*arr-literal*", "void"]]);
 	//q{int* b;}.expectSymbolsAndTypes([["b", "*", "int"]]);
 	//q{int*[] b;}.expectSymbolsAndTypes([["b", "*arr*", "*", "int"]]);
 


### PR DESCRIPTION
not a critical feature, rather just to make the things correctly

```d
auto v = [];    // initializer
v ~= [];        // literal
static assert (is(typeof(v) == void[]));
static assert (is(typeof([]) == void[]));  
```