### PR TITLE
Make `ModuleCache` recursion guard using `char` ptr instead of `string`

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -165,13 +165,13 @@ struct ModuleCache
 
 		istring cachedLocation = internString(location);
 
-		if (recursionGuard.contains(cachedLocation))
+		if (recursionGuard.contains(&cachedLocation.data[0]))
 			return null;
 
 		if (!needsReparsing(cachedLocation))
 			return getEntryFor(cachedLocation).symbol;
 
-		recursionGuard.insert(cachedLocation);
+		recursionGuard.insert(&cachedLocation.data[0]);
 
 		File f = File(cachedLocation);
 		immutable fileSize = cast(size_t) f.size;
@@ -236,7 +236,7 @@ struct ModuleCache
 		}
 
 		cache.insert(newEntry);
-		recursionGuard.remove(cachedLocation);
+		recursionGuard.remove(&cachedLocation.data[0]);
 
 		resolveDeferredTypes(cachedLocation);
 
@@ -424,7 +424,7 @@ private:
 	// Mapping of file paths to their cached symbols.
 	TTree!(CacheEntry*) cache;
 
-	HashSet!string recursionGuard;
+	HashSet!(immutable(char)*) recursionGuard;
 
 	struct ImportPath
 	{

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -268,6 +268,15 @@ unittest
 	assert(T2.kind == CompletionKind.variadicTmpParam);
 }
 
+// this is for testing that internString data is always on the same address
+// since we use this special property for modulecache recursion guard
+unittest
+{
+	istring a = internString("foo_bar_baz".idup);
+	istring b = internString("foo_bar_baz".idup);
+	assert(a.data.ptr == b.data.ptr);
+}
+
 static StringCache stringCache = void;
 static this()
 {


### PR DESCRIPTION
Since strings representing the module name are actually `istring` we can store the first character of the module being cached.