### PR TITLE
fix anonymous struct members not located in the parent symbol

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -807,7 +807,8 @@ private:
 
 	void visitAggregateDeclaration(AggType)(AggType dec, CompletionKind kind)
 	{
-		if (kind == CompletionKind.unionName && dec.name == tok!"")
+		if ((kind == CompletionKind.unionName || kind == CompletionKind.structName) &&
+			dec.name == tok!"")
 		{
 			dec.accept(this);
 			return;

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -165,6 +165,19 @@ unittest
 {
 	ModuleCache cache = ModuleCache(theAllocator);
 
+	writeln("Running anon struct tests...");
+	auto source = q{ struct A { struct {int a;}} };
+	auto pair = generateAutocompleteTrees(source, cache);
+	auto A = pair.symbol.getFirstPartNamed(internString("A"));
+	assert(A);
+	auto Aa = A.getFirstPartNamed(internString("a"));
+	assert(Aa);
+}
+
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+
 	writeln("Running the deduction from index expr tests...");
 	{
 		auto source = q{struct S{} S[] s; auto b = s[i];};


### PR DESCRIPTION
This will fix this DCD issue : https://github.com/dlang-community/DCD/issues/593