### PR TITLE
fix #57 - Type resolution of forward referenced fields and methods not working

### DIFF
--- a/src/dsymbol/semantic.d
+++ b/src/dsymbol/semantic.d
@@ -88,6 +88,9 @@ public:
 
 	/// Protection level for this symobol
 	IdType protection;
+
+	/// Flag used to solve forward declarations
+	bool secondPassDone;
 }
 
 /**

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -261,6 +261,30 @@ unittest
 {
 	ModuleCache cache = ModuleCache(theAllocator);
 
+	writeln("Running the forwared declarations tests...");
+	auto source = q{
+
+		enum MyAggregate a = {};
+		auto varA = a.field;
+		auto varB = a.func;
+		struct MyAggregate
+		{
+		    int field;
+		    int func() { return 0; }
+		}
+	};
+	auto pair = generateAutocompleteTrees(source, cache);
+	assert(pair.symbol);
+	auto A = pair.symbol.getFirstPartNamed(internString("varA"));
+	assert(A);
+	assert(A.type);
+	assert(A.type.name == "int");
+}
+
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+
 	writeln("Running template type parameters tests...");
 	{
 		auto source = q{ struct Foo(T : int){} struct Bar(T : Foo){} };


### PR DESCRIPTION
Run again the second pass, up to 10 times max, if unsolved types are detected.