### PR TITLE
Fixes for memory leaks on thread termination + refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.d]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,32 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.a
+*.lib
+
+# Executables
+*.exe
+
+# DUB
 .dub/
+docs/
+docs.json
+__dummy.html
+
+# Code coverage
+*.lst
+
+# Others
+build/
+*.~*
+*.*~
 dub.selections.json
-libdsymbol.a
+trace.def
+.vscode/

--- a/dub.json
+++ b/dub.json
@@ -1,9 +1,10 @@
 {
 	"name": "dsymbol",
-	"targetType": "library",
 	"description": "Symbol lookup support for libdparse",
 	"license": "BSL-1.0",
 	"authors": ["Brian Schott"],
+	"targetPath": "build",
+	"targetType": "library",
 	"dependencies": {
 		"libdparse": "~>0.13.0",
 		"emsi_containers": "~>0.8.0-alpha.15",

--- a/src/dsymbol/builtin/names.d
+++ b/src/dsymbol/builtin/names.d
@@ -169,37 +169,37 @@ static this()
 
 istring symbolNameToTypeName(istring name)
 {
-	if (name.ptr == DOUBLE_LITERAL_SYMBOL_NAME.ptr)
+	if (name == DOUBLE_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[2];
-	if (name.ptr == FLOAT_LITERAL_SYMBOL_NAME.ptr)
+	if (name == FLOAT_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[4];
-	if (name.ptr == IDOUBLE_LITERAL_SYMBOL_NAME.ptr)
+	if (name == IDOUBLE_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[3];
-	if (name.ptr == IFLOAT_LITERAL_SYMBOL_NAME.ptr)
+	if (name == IFLOAT_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[5];
-	if (name.ptr == INT_LITERAL_SYMBOL_NAME.ptr)
+	if (name == INT_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[0];
-	if (name.ptr == LONG_LITERAL_SYMBOL_NAME.ptr)
+	if (name == LONG_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[8];
-	if (name.ptr == REAL_LITERAL_SYMBOL_NAME.ptr)
+	if (name == REAL_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[17];
-	if (name.ptr == IREAL_LITERAL_SYMBOL_NAME.ptr)
+	if (name == IREAL_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[18];
-	if (name.ptr == UINT_LITERAL_SYMBOL_NAME.ptr)
+	if (name == UINT_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[1];
-	if (name.ptr == ULONG_LITERAL_SYMBOL_NAME.ptr)
+	if (name == ULONG_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[9];
-	if (name.ptr == CHAR_LITERAL_SYMBOL_NAME.ptr)
+	if (name == CHAR_LITERAL_SYMBOL_NAME)
 		return builtinTypeNames[10];
-	if (name.ptr == DSTRING_LITERAL_SYMBOL_NAME.ptr)
-		return internString("dstring");
-	if (name.ptr == STRING_LITERAL_SYMBOL_NAME.ptr)
-		return internString("string");
-	if (name.ptr == WSTRING_LITERAL_SYMBOL_NAME.ptr)
-		return internString("wstring");
-	if (name.ptr == BOOL_VALUE_SYMBOL_NAME.ptr)
-		return internString("bool");
-	if (name.ptr == VOID_SYMBOL_NAME.ptr)
-		return internString("void");
+	if (name == DSTRING_LITERAL_SYMBOL_NAME)
+		return istring("dstring");
+	if (name == STRING_LITERAL_SYMBOL_NAME)
+		return istring("string");
+	if (name == WSTRING_LITERAL_SYMBOL_NAME)
+		return istring("wstring");
+	if (name == BOOL_VALUE_SYMBOL_NAME)
+		return istring("bool");
+	if (name == VOID_SYMBOL_NAME)
+		return istring("void");
 	return name;
 }

--- a/src/dsymbol/builtin/symbols.d
+++ b/src/dsymbol/builtin/symbols.d
@@ -50,36 +50,36 @@ DSymbol* typeTmpParamSymbol;
 
 static this()
 {
-	auto bool_ = make!DSymbol(Mallocator.instance, builtinTypeNames[13], CompletionKind.keyword);
-	auto int_ = make!DSymbol(Mallocator.instance, builtinTypeNames[0], CompletionKind.keyword);
-	auto long_ = make!DSymbol(Mallocator.instance, builtinTypeNames[8], CompletionKind.keyword);
-	auto byte_ = make!DSymbol(Mallocator.instance, builtinTypeNames[19], CompletionKind.keyword);
-	auto char_ = make!DSymbol(Mallocator.instance, builtinTypeNames[10], CompletionKind.keyword);
-	auto dchar_ = make!DSymbol(Mallocator.instance, builtinTypeNames[12], CompletionKind.keyword);
-	auto short_ = make!DSymbol(Mallocator.instance, builtinTypeNames[6], CompletionKind.keyword);
-	auto ubyte_ = make!DSymbol(Mallocator.instance, builtinTypeNames[20], CompletionKind.keyword);
-	auto uint_ = make!DSymbol(Mallocator.instance, builtinTypeNames[1], CompletionKind.keyword);
-	auto ulong_ = make!DSymbol(Mallocator.instance, builtinTypeNames[9], CompletionKind.keyword);
-	auto ushort_ = make!DSymbol(Mallocator.instance, builtinTypeNames[7], CompletionKind.keyword);
-	auto wchar_ = make!DSymbol(Mallocator.instance, builtinTypeNames[11], CompletionKind.keyword);
+	auto bool_ = makeSymbol(builtinTypeNames[13], CompletionKind.keyword);
+	auto int_ = makeSymbol(builtinTypeNames[0], CompletionKind.keyword);
+	auto long_ = makeSymbol(builtinTypeNames[8], CompletionKind.keyword);
+	auto byte_ = makeSymbol(builtinTypeNames[19], CompletionKind.keyword);
+	auto char_ = makeSymbol(builtinTypeNames[10], CompletionKind.keyword);
+	auto dchar_ = makeSymbol(builtinTypeNames[12], CompletionKind.keyword);
+	auto short_ = makeSymbol(builtinTypeNames[6], CompletionKind.keyword);
+	auto ubyte_ = makeSymbol(builtinTypeNames[20], CompletionKind.keyword);
+	auto uint_ = makeSymbol(builtinTypeNames[1], CompletionKind.keyword);
+	auto ulong_ = makeSymbol(builtinTypeNames[9], CompletionKind.keyword);
+	auto ushort_ = makeSymbol(builtinTypeNames[7], CompletionKind.keyword);
+	auto wchar_ = makeSymbol(builtinTypeNames[11], CompletionKind.keyword);
 
-	auto alignof_ = make!DSymbol(Mallocator.instance, internString("alignof"), CompletionKind.keyword);
-	auto mangleof_ = make!DSymbol(Mallocator.instance, internString("mangleof"), CompletionKind.keyword);
-	auto sizeof_ = make!DSymbol(Mallocator.instance, internString("sizeof"), CompletionKind.keyword);
-	auto stringof_ = make!DSymbol(Mallocator.instance, internString("stringof"), CompletionKind.keyword);
-	auto init = make!DSymbol(Mallocator.instance, internString("init"), CompletionKind.keyword);
-	auto min = make!DSymbol(Mallocator.instance, internString("min"), CompletionKind.keyword);
-	auto max = make!DSymbol(Mallocator.instance, internString("max"), CompletionKind.keyword);
-	auto dup = make!DSymbol(Mallocator.instance, internString("dup"), CompletionKind.keyword);
-	auto length = make!DSymbol(Mallocator.instance, internString("length"), CompletionKind.keyword, ulong_);
-	auto tupleof = make!DSymbol(Mallocator.instance, internString("tupleof"), CompletionKind.keyword);
+	auto alignof_ = makeSymbol("alignof", CompletionKind.keyword);
+	auto mangleof_ = makeSymbol("mangleof", CompletionKind.keyword);
+	auto sizeof_ = makeSymbol("sizeof", CompletionKind.keyword);
+	auto stringof_ = makeSymbol("stringof", CompletionKind.keyword);
+	auto init = makeSymbol("init", CompletionKind.keyword);
+	auto min = makeSymbol("min", CompletionKind.keyword);
+	auto max = makeSymbol("max", CompletionKind.keyword);
+	auto dup = makeSymbol("dup", CompletionKind.keyword);
+	auto length = makeSymbol("length", CompletionKind.keyword, ulong_);
+	auto tupleof = makeSymbol("tupleof", CompletionKind.keyword);
 
-	variadicTmpParamSymbol = make!DSymbol(Mallocator.instance, internString("variadicTmpParam"), CompletionKind.keyword);
+	variadicTmpParamSymbol = makeSymbol("variadicTmpParam", CompletionKind.keyword);
 	variadicTmpParamSymbol.addChild(init, false);
 	variadicTmpParamSymbol.addChild(length, false);
 	variadicTmpParamSymbol.addChild(stringof_, false);
 
-	typeTmpParamSymbol = make!DSymbol(Mallocator.instance, internString("typeTmpParam"), CompletionKind.keyword);
+	typeTmpParamSymbol = makeSymbol("typeTmpParam", CompletionKind.keyword);
 	typeTmpParamSymbol.addChild(alignof_, false);
 	typeTmpParamSymbol.addChild(init, false);
 	typeTmpParamSymbol.addChild(mangleof_, false);
@@ -88,29 +88,29 @@ static this()
 
 	arraySymbols.insert(alignof_);
 	arraySymbols.insert(dup);
-	arraySymbols.insert(make!DSymbol(Mallocator.instance, internString("idup"), CompletionKind.keyword));
+	arraySymbols.insert(makeSymbol("idup", CompletionKind.keyword));
 	arraySymbols.insert(init);
 	arraySymbols.insert(length);
 	arraySymbols.insert(mangleof_);
-	arraySymbols.insert(make!DSymbol(Mallocator.instance, internString("ptr"), CompletionKind.keyword));
+	arraySymbols.insert(makeSymbol("ptr", CompletionKind.keyword));
 	arraySymbols.insert(sizeof_);
 	arraySymbols.insert(stringof_);
 
 	assocArraySymbols.insert(alignof_);
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("byKey"), CompletionKind.keyword));
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("byValue"), CompletionKind.keyword));
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("clear"), CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("byKey", CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("byValue", CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("clear", CompletionKind.keyword));
 	assocArraySymbols.insert(dup);
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("get"), CompletionKind.keyword));
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("init"), CompletionKind.keyword));
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("keys"), CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("get", CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("init", CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("keys", CompletionKind.keyword));
 	assocArraySymbols.insert(length);
 	assocArraySymbols.insert(mangleof_);
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("rehash"), CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("rehash", CompletionKind.keyword));
 	assocArraySymbols.insert(sizeof_);
 	assocArraySymbols.insert(stringof_);
 	assocArraySymbols.insert(init);
-	assocArraySymbols.insert(make!DSymbol(Mallocator.instance, internString("values"), CompletionKind.keyword));
+	assocArraySymbols.insert(makeSymbol("values", CompletionKind.keyword));
 
 	DSymbol*[12] integralTypeArray;
 	integralTypeArray[0] = bool_;
@@ -128,26 +128,26 @@ static this()
 
 	foreach (s; integralTypeArray)
 	{
-		s.addChild(make!DSymbol(Mallocator.instance, internString("init"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("min"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("max"), CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("init", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("min", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("max", CompletionKind.keyword, s), true);
 		s.addChild(alignof_, false);
 		s.addChild(sizeof_, false);
 		s.addChild(stringof_, false);
 		s.addChild(mangleof_, false);
 	}
 
-	auto cdouble_ = make!DSymbol(Mallocator.instance, builtinTypeNames[21], CompletionKind.keyword);
-	auto cent_ = make!DSymbol(Mallocator.instance, builtinTypeNames[15], CompletionKind.keyword);
-	auto cfloat_ = make!DSymbol(Mallocator.instance, builtinTypeNames[22], CompletionKind.keyword);
-	auto creal_ = make!DSymbol(Mallocator.instance, builtinTypeNames[23], CompletionKind.keyword);
-	auto double_ = make!DSymbol(Mallocator.instance, builtinTypeNames[2], CompletionKind.keyword);
-	auto float_ = make!DSymbol(Mallocator.instance, builtinTypeNames[4], CompletionKind.keyword);
-	auto idouble_ = make!DSymbol(Mallocator.instance, builtinTypeNames[3], CompletionKind.keyword);
-	auto ifloat_ = make!DSymbol(Mallocator.instance, builtinTypeNames[5], CompletionKind.keyword);
-	auto ireal_ = make!DSymbol(Mallocator.instance, builtinTypeNames[18], CompletionKind.keyword);
-	auto real_ = make!DSymbol(Mallocator.instance, builtinTypeNames[17], CompletionKind.keyword);
-	auto ucent_ = make!DSymbol(Mallocator.instance, builtinTypeNames[16], CompletionKind.keyword);
+	auto cdouble_ = makeSymbol(builtinTypeNames[21], CompletionKind.keyword);
+	auto cent_ = makeSymbol(builtinTypeNames[15], CompletionKind.keyword);
+	auto cfloat_ = makeSymbol(builtinTypeNames[22], CompletionKind.keyword);
+	auto creal_ = makeSymbol(builtinTypeNames[23], CompletionKind.keyword);
+	auto double_ = makeSymbol(builtinTypeNames[2], CompletionKind.keyword);
+	auto float_ = makeSymbol(builtinTypeNames[4], CompletionKind.keyword);
+	auto idouble_ = makeSymbol(builtinTypeNames[3], CompletionKind.keyword);
+	auto ifloat_ = makeSymbol(builtinTypeNames[5], CompletionKind.keyword);
+	auto ireal_ = makeSymbol(builtinTypeNames[18], CompletionKind.keyword);
+	auto real_ = makeSymbol(builtinTypeNames[17], CompletionKind.keyword);
+	auto ucent_ = makeSymbol(builtinTypeNames[16], CompletionKind.keyword);
 
 	DSymbol*[11] floatTypeArray;
 	floatTypeArray[0] = cdouble_;
@@ -165,19 +165,19 @@ static this()
 	foreach (s; floatTypeArray)
 	{
 		s.addChild(alignof_, false);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("dig"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("epsilon"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("infinity"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("init"), CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("dig", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("epsilon", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("infinity", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("init", CompletionKind.keyword, s), true);
 		s.addChild(mangleof_, false);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("mant_dig"), CompletionKind.keyword, int_), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("max"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("max_10_exp"), CompletionKind.keyword, int_), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("max_exp"), CompletionKind.keyword, int_), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("min_exp"), CompletionKind.keyword, int_), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("min_10_exp"), CompletionKind.keyword, int_), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("min_normal"), CompletionKind.keyword, s), true);
-		s.addChild(make!DSymbol(Mallocator.instance, internString("nan"), CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("mant_dig", CompletionKind.keyword, int_), true);
+		s.addChild(makeSymbol("max", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("max_10_exp", CompletionKind.keyword, int_), true);
+		s.addChild(makeSymbol("max_exp", CompletionKind.keyword, int_), true);
+		s.addChild(makeSymbol("min_exp", CompletionKind.keyword, int_), true);
+		s.addChild(makeSymbol("min_10_exp", CompletionKind.keyword, int_), true);
+		s.addChild(makeSymbol("min_normal", CompletionKind.keyword, s), true);
+		s.addChild(makeSymbol("nan", CompletionKind.keyword, s), true);
 		s.addChild(sizeof_, false);
 		s.addChild(stringof_, false);
 	}
@@ -189,10 +189,10 @@ static this()
 	aggregateSymbols.insert(stringof_);
 	aggregateSymbols.insert(init);
 
-	classSymbols.insert(make!DSymbol(Mallocator.instance, internString("classinfo"), CompletionKind.variableName));
+	classSymbols.insert(makeSymbol("classinfo", CompletionKind.variableName));
 	classSymbols.insert(tupleof);
-	classSymbols.insert(make!DSymbol(Mallocator.instance, internString("__vptr"), CompletionKind.variableName));
-	classSymbols.insert(make!DSymbol(Mallocator.instance, internString("__monitor"), CompletionKind.variableName));
+	classSymbols.insert(makeSymbol("__vptr", CompletionKind.variableName));
+	classSymbols.insert(makeSymbol("__monitor", CompletionKind.variableName));
 	classSymbols.insert(mangleof_);
 	classSymbols.insert(alignof_);
 	classSymbols.insert(sizeof_);
@@ -208,14 +208,14 @@ static this()
 	enumSymbols.insert(max);
 
 
-	ireal_.addChild(make!DSymbol(Mallocator.instance, internString("im"), CompletionKind.keyword, real_), true);
-	ifloat_.addChild(make!DSymbol(Mallocator.instance, internString("im"), CompletionKind.keyword, float_), true);
-	idouble_.addChild(make!DSymbol(Mallocator.instance, internString("im"), CompletionKind.keyword, double_), true);
-	ireal_.addChild(make!DSymbol(Mallocator.instance, internString("re"), CompletionKind.keyword, real_), true);
-	ifloat_.addChild(make!DSymbol(Mallocator.instance, internString("re"), CompletionKind.keyword, float_), true);
-	idouble_.addChild(make!DSymbol(Mallocator.instance, internString("re"), CompletionKind.keyword, double_), true);
+	ireal_.addChild(makeSymbol("im", CompletionKind.keyword, real_), true);
+	ifloat_.addChild(makeSymbol("im", CompletionKind.keyword, float_), true);
+	idouble_.addChild(makeSymbol("im", CompletionKind.keyword, double_), true);
+	ireal_.addChild(makeSymbol("re", CompletionKind.keyword, real_), true);
+	ifloat_.addChild(makeSymbol("re", CompletionKind.keyword, float_), true);
+	idouble_.addChild(makeSymbol("re", CompletionKind.keyword, double_), true);
 
-	auto void_ = make!DSymbol(Mallocator.instance, builtinTypeNames[14], CompletionKind.keyword);
+	auto void_ = makeSymbol(builtinTypeNames[14], CompletionKind.keyword);
 
 	builtinSymbols.insert(bool_);
 	bool_.type = bool_;
@@ -270,5 +270,14 @@ static this()
 	foreach (s; ["__DATE__", "__EOF__", "__TIME__", "__TIMESTAMP__", "__VENDOR__",
 			"__VERSION__", "__FUNCTION__", "__PRETTY_FUNCTION__", "__MODULE__",
 			"__FILE__", "__LINE__", "__FILE_FULL_PATH__"])
-		builtinSymbols.insert(make!DSymbol(Mallocator.instance, internString(s), CompletionKind.keyword));
+		builtinSymbols.insert(makeSymbol(s, CompletionKind.keyword));
+}
+
+private DSymbol* makeSymbol(string s, CompletionKind kind, DSymbol* type = null)
+{
+	return make!DSymbol(Mallocator.instance, internString(s), kind, type);
+}
+private DSymbol* makeSymbol(istring s, CompletionKind kind, DSymbol* type = null)
+{
+	return make!DSymbol(Mallocator.instance, s, kind, type);
 }

--- a/src/dsymbol/cache_entry.d
+++ b/src/dsymbol/cache_entry.d
@@ -28,17 +28,19 @@ struct CacheEntry
 			typeid(DSymbol).destroy(symbol);
 	}
 
-	ptrdiff_t opCmp(ref const CacheEntry other) const pure nothrow @nogc @trusted
+pure nothrow @nogc @safe:
+
+	ptrdiff_t opCmp(ref const CacheEntry other) const
 	{
-		return (cast(size_t) path.ptr) - (cast(size_t) other.path.ptr);
+		return path.opCmp(other.path);
 	}
 
-	bool opEquals(ref const CacheEntry other) const pure nothrow @nogc @trusted
+	bool opEquals(ref const CacheEntry other) const
 	{
-		return path.ptr is other.path.ptr;
+		return path == other.path;
 	}
 
-	size_t toHash() const nothrow @safe
+	size_t toHash() const
 	{
 		return path.toHash();
 	}

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -741,7 +741,7 @@ private:
 		import std.array : appender;
 		import std.range : zip;
 
-		auto app = appender!(char[])();
+		auto app = appender!string();
 		app.put("this(");
 		bool first = true;
 		foreach (field; zip(structFieldTypes[], structFieldNames[]))
@@ -757,12 +757,12 @@ private:
 				app.formatNode(field[0]);
 				app.put(" ");
 			}
-			app.put(field[1]);
+			app.put(field[1].data);
 		}
 		app.put(")");
 		SemanticSymbol* symbol = allocateSemanticSymbol(CONSTRUCTOR_SYMBOL_NAME,
 			CompletionKind.functionName, symbolFile, currentSymbol.acSymbol.location);
-		symbol.acSymbol.callTip = internString(cast(string) app.data);
+		symbol.acSymbol.callTip = istring(app.data);
 		currentSymbol.addChild(symbol, true);
 	}
 
@@ -1024,7 +1024,7 @@ private:
 	{
 		import std.array : appender;
 
-		auto app = appender!(char[])();
+		auto app = appender!string();
 		if (returnType !is null)
 		{
 			app.formatNode(returnType);
@@ -1037,7 +1037,7 @@ private:
 			app.put("()");
 		else
 			app.formatNode(parameters);
-		return internString(cast(string) app.data);
+		return istring(app.data);
 	}
 
 	void populateInitializer(T)(SemanticSymbol* symbol, const T initializer,
@@ -1100,9 +1100,9 @@ private:
 			else if (suffix.delegateOrFunction != tok!"")
 			{
 				import std.array : appender;
-				auto app = appender!(char[])();
+				auto app = appender!string();
 				formatNode(app, type);
-				istring callTip = internString(cast(string) app.data);
+				istring callTip = istring(app.data);
 				// Insert the call tip and THEN the "function" string because
 				// the breadcrumbs are processed in reverse order
 				lookup.breadcrumbs.insert(callTip);
@@ -1308,14 +1308,14 @@ static istring convertChainToImportPath(const IdentifierChain ic)
 {
 	import std.path : dirSeparator;
 	import std.array : appender;
-	auto app = appender!(char[])();
+	auto app = appender!string();
 	foreach (i, ident; ic.identifiers)
 	{
 		app.put(ident.text);
 		if (i + 1 < ic.identifiers.length)
 			app.put(dirSeparator);
 	}
-	return internString(cast(string) app.data);
+	return istring(app.data);
 }
 
 class InitializerVisitor : ASTVisitor
@@ -1462,7 +1462,7 @@ class InitializerVisitor : ASTVisitor
 
 		// here we follow DMDFE naming style
 		__gshared size_t anonIndex;
-		istring idt = "__anonclass%d".format(++anonIndex).internString;
+		const idt = istring("__anonclass%d".format(++anonIndex));
 
 		// the goal is to replace it so we null the field
 		NewAnonClassExpression nace = ne.newAnonClassExpression;

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -1057,7 +1057,7 @@ private:
 	}
 	body
 	{
-		DSymbol* acSymbol = make!DSymbol(symbolAllocator, name, kind);
+		DSymbol* acSymbol = make!DSymbol(symbolAllocator, istring(name), kind);
 		acSymbol.location = location;
 		acSymbol.symbolFile = symbolFile;
 		symbolsAllocated++;

--- a/src/dsymbol/deferred.d
+++ b/src/dsymbol/deferred.d
@@ -43,7 +43,7 @@ struct DeferredSymbol
 	bool dependsOn(istring modulePath)
 	{
 		foreach (i; imports[])
-			if (i.symbolFile.ptr == modulePath.ptr)
+			if (i.symbolFile == modulePath)
 				return true;
 		return false;
 	}

--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -88,14 +88,13 @@ struct ModuleCache
 	 */
 	void addImportPaths(const string[] paths)
 	{
-		import dsymbol.string_interning : internString;
 		import std.path : baseName;
 		import std.array : array;
 
 		auto newPaths = paths
 			.map!(a => absolutePath(expandTilde(a)))
 			.filter!(a => existanceCheck(a) && !importPaths[].canFind!(b => b.path == a))
-			.map!(a => ImportPath(internString(a)))
+			.map!(a => ImportPath(istring(a)))
 			.array;
 		importPaths.insert(newPaths);
 	}
@@ -119,9 +118,9 @@ struct ModuleCache
 
 			foreach (cacheEntry; cache[])
 			{
-				if (cacheEntry.path.startsWith(path))
+				if (cacheEntry.path.data.startsWith(path))
 				{
-					foreach (deferredSymbol; deferredSymbols[].find!(d => d.symbol.symbolFile.startsWith(cacheEntry.path)))
+					foreach (deferredSymbol; deferredSymbols[].find!(d => d.symbol.symbolFile.data.startsWith(cacheEntry.path.data)))
 					{
 						deferredSymbols.remove(deferredSymbol);
 						Mallocator.instance.dispose(deferredSymbol);
@@ -157,13 +156,12 @@ struct ModuleCache
 	 */
 	DSymbol* cacheModule(string location)
 	{
-		import dsymbol.string_interning : internString;
 		import std.stdio : File;
 		import std.typecons : scoped;
 
 		assert (location !is null);
 
-		istring cachedLocation = internString(location);
+		const cachedLocation = istring(location);
 
 		if (recursionGuard.contains(&cachedLocation.data[0]))
 			return null;
@@ -299,7 +297,7 @@ struct ModuleCache
 	{
 		assert(moduleName !is null, "module name is null");
 		if (isRooted(moduleName))
-			return internString(moduleName);
+			return istring(moduleName);
 		string[] alternatives;
 		foreach (importPath; importPaths[])
 		{
@@ -331,7 +329,7 @@ struct ModuleCache
 				}
 			}
 		}
-		return alternatives.length > 0 ? internString(alternatives[0]) : istring(null);
+		return alternatives.length > 0 ? istring(alternatives[0]) : istring(null);
 	}
 
 	auto getImportPaths() const

--- a/src/dsymbol/scope_.d
+++ b/src/dsymbol/scope_.d
@@ -156,10 +156,10 @@ struct Scope
 				return cast(typeof(return)) app.data;
 		}
 
-		if (name.ptr != CONSTRUCTOR_SYMBOL_NAME.ptr
-				&& name.ptr != DESTRUCTOR_SYMBOL_NAME.ptr
-				&& name.ptr != UNITTEST_SYMBOL_NAME.ptr
-				&& name.ptr != THIS_SYMBOL_NAME.ptr)
+		if (name != CONSTRUCTOR_SYMBOL_NAME &&
+			name != DESTRUCTOR_SYMBOL_NAME &&
+			name != UNITTEST_SYMBOL_NAME &&
+			name != THIS_SYMBOL_NAME)
 		{
 			// Check imported symbols
 			DSymbol ir = DSymbol(IMPORT_SYMBOL_NAME);
@@ -169,8 +169,7 @@ struct Scope
 			{
 				if (e.type is null)
 					continue;
-				if (e.qualifier == SymbolQualifier.selectiveImport &&
-						e.type.name.ptr == name.ptr)
+				if (e.qualifier == SymbolQualifier.selectiveImport && e.type.name == name)
 					app.put(cast(DSymbol*) e.type);
 				else
 					foreach (importedSymbol; e.type.getPartsByName(s.name))

--- a/src/dsymbol/semantic.d
+++ b/src/dsymbol/semantic.d
@@ -133,3 +133,22 @@ static this()
 	argumentsType.typeSuffixes = cast(TypeSuffix[]) Mallocator.instance.allocate(TypeSuffix.sizeof);
 	argumentsType.typeSuffixes[0] = argumentsTypeSuffix;
 }
+
+static ~this()
+{
+	import stdx.allocator : dispose;
+	import stdx.allocator.mallocator : Mallocator;
+
+	dispose(Mallocator.instance, argumentsType.typeSuffixes[0]);
+	dispose(Mallocator.instance, argumentsType.type2.typeIdentifierPart.identifierOrTemplateInstance);
+	dispose(Mallocator.instance, argumentsType.type2.typeIdentifierPart);
+	dispose(Mallocator.instance, argumentsType.type2);
+	dispose(Mallocator.instance, argptrType.typeSuffixes[0]);
+	dispose(Mallocator.instance, argptrType.type2);
+
+	Mallocator.instance.deallocate(argumentsType.typeSuffixes);
+	Mallocator.instance.deallocate(argptrType.typeSuffixes);
+
+	dispose(Mallocator.instance, argumentsType);
+	dispose(Mallocator.instance, argptrType);
+}

--- a/src/dsymbol/string_interning.d
+++ b/src/dsymbol/string_interning.d
@@ -32,6 +32,11 @@ static this()
 	stringCache = StringCache(StringCache.defaultBucketCount);
 }
 
+static ~this()
+{
+	destroy(stringCache);
+}
+
 private StringCache stringCache = void;
 
 struct istring

--- a/src/dsymbol/string_interning.d
+++ b/src/dsymbol/string_interning.d
@@ -18,14 +18,13 @@
 
 module dsymbol.string_interning;
 
+import std.traits : Unqual;
 import dparse.lexer;
 
-/**
- * Interns the given string and returns the interned version.
- */
-istring internString(string s) nothrow @safe @nogc
+/// Obsolete, use `istring` constructor instead
+istring internString(string s) nothrow @nogc @safe
 {
-	return istring(stringCache.intern(s));
+	return istring(s);
 }
 
 static this()
@@ -33,24 +32,61 @@ static this()
 	stringCache = StringCache(StringCache.defaultBucketCount);
 }
 
-alias istring = InternedString;
-
 private StringCache stringCache = void;
 
-private struct InternedString
+struct istring
 {
+nothrow @nogc @safe:
+	/// Interns the given string and returns the interned version. Handles empty strings too.
+	this(string s)
+	{
+		if (s.length > 0)
+			_data = stringCache.intern(s);
+	}
+
+pure:
 	void opAssign(T)(T other) if (is(Unqual!T == istring))
 	{
-		this.data = other.data;
+		_data = other._data;
 	}
 
-	size_t toHash() const nothrow @safe
+	bool opCast(To : bool)() const
 	{
-		return typeid(string).getHash(&data);
+		return _data.length > 0;
 	}
 
-	string data;
+	ptrdiff_t opCmp(const istring another) const @trusted
+	{
+		// Interned strings can be compared by the pointers.
+		// Identical strings MUST have the same address
+		return (cast(ptrdiff_t) _data.ptr) - (cast(ptrdiff_t) another._data.ptr);
+	}
+	ptrdiff_t opCmp(const string another) const
+	{
+		import std.algorithm.comparison : cmp;
+		// Compare as usual, because another string may come from somewhere else
+		return cmp(_data, another);
+	}
+
+	bool opEquals(const istring another) const @trusted
+	{
+		return _data.ptr is another._data.ptr;
+	}
+	bool opEquals(const string another) const
+	{
+		return _data == another;
+	}
+
+	size_t toHash() const @trusted
+	{
+		return (cast(size_t) _data.ptr) * 27_644_437;
+	}
+
+	string data() const
+	{
+		return _data;
+	}
+
 	alias data this;
-private:
-	import std.traits : Unqual;
+	private string _data;
 }

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -145,6 +145,13 @@ struct DSymbol
 	 *     kind = the symbol's completion kind
 	 *     type = the resolved type of the symbol
 	 */
+	this(string name, CompletionKind kind = CompletionKind.dummy, DSymbol* type = null) nothrow @nogc @safe
+	{
+		this.name = istring(name);
+		this.kind = kind;
+		this.type = type;
+	}
+	/// ditto
 	this(istring name, CompletionKind kind = CompletionKind.dummy, DSymbol* type = null) nothrow @nogc @safe
 	{
 		this.name = name;

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -30,8 +30,7 @@ import dparse.lexer;
 import std.bitmanip;
 
 import dsymbol.builtin.names;
-import dsymbol.string_interning;
-public import dsymbol.string_interning : istring;
+public import dsymbol.string_interning;
 
 import std.range : isOutputRange;
 
@@ -159,7 +158,7 @@ public:
 	 */
 	this(string name, CompletionKind kind) /+nothrow+/ /+@safe+/ /+@nogc+/
 	{
-		this.name = name is null ? istring(name) : internString(name);
+		this.name = istring(name);
 		this.kind = kind;
 	}
 
@@ -178,7 +177,7 @@ public:
 	 */
 	this(string name, CompletionKind kind, DSymbol* type)
 	{
-		this.name = name is null ? istring(name) : internString(name);
+		this.name = istring(name);
 		this.kind = kind;
 		this.type = type;
 	}
@@ -207,21 +206,19 @@ public:
 			typeid(DSymbol).destroy(type);
 	}
 
-	ptrdiff_t opCmp(ref const DSymbol other) const pure nothrow @trusted @nogc
+	ptrdiff_t opCmp(ref const DSymbol other) const pure nothrow @nogc @safe
 	{
-		// Compare the pointers because the strings have been interned.
-		// Identical strings MUST have the same address
-		return (cast(size_t) name.ptr) - (cast(size_t) other.name.ptr);
+		return name.opCmp(other.name);
 	}
 
-	bool opEquals(ref const DSymbol other) const pure nothrow @trusted
+	bool opEquals(ref const DSymbol other) const pure nothrow @nogc @safe
 	{
-		return other.name.ptr is this.name.ptr;
+		return name == other.name;
 	}
 
-	size_t toHash() const pure nothrow @trusted
+	size_t toHash() const pure nothrow @nogc @safe
 	{
-		return (cast(size_t) name.ptr) * 27_644_437;
+		return name.toHash();
 	}
 
 	/**
@@ -261,7 +258,7 @@ public:
 
 		DSymbol p = DSymbol(IMPORT_SYMBOL_NAME);
 		if (qualifier == SymbolQualifier.selectiveImport && type !is null
-				&& (name is null ? true : type.name.ptr == name.ptr))
+				&& (name is null || type.name == name))
 		{
 			app.put(cast(DSymbol*) type);
 			if (onlyOne)
@@ -269,7 +266,7 @@ public:
 		}
 		else
 		{
-			if (name == "")
+			if (name is null)
 			{
 				foreach (part; parts[].filter!(a => a.name != IMPORT_SYMBOL_NAME))
 				{
@@ -290,10 +287,10 @@ public:
 					if (onlyOne)
 						return;
 				}
-				if (name.ptr == CONSTRUCTOR_SYMBOL_NAME.ptr
-						|| name.ptr == DESTRUCTOR_SYMBOL_NAME.ptr
-						|| name.ptr == UNITTEST_SYMBOL_NAME.ptr
-						|| name.ptr == THIS_SYMBOL_NAME.ptr)
+				if (name == CONSTRUCTOR_SYMBOL_NAME ||
+					name == DESTRUCTOR_SYMBOL_NAME ||
+					name == UNITTEST_SYMBOL_NAME ||
+					name == THIS_SYMBOL_NAME)
 					return;	// these symbols should not be imported
 				foreach (im; parts.equalRange(SymbolOwnership(&p)))
 					if (im.type !is null && !im.skipOver)
@@ -309,7 +306,7 @@ public:
 	{
 		auto app = appender!(DSymbol*[])();
 		HashSet!size_t visited;
-		getParts!(typeof(app))(internString(null), app, visited);
+		getParts!(typeof(app))(istring(null), app, visited);
 		return cast(typeof(return)) app.data;
 	}
 
@@ -465,7 +462,7 @@ struct UpdatePair
 {
 	ptrdiff_t opCmp(ref const UpdatePair other) const pure nothrow @nogc @safe
 	{
-		return (cast(size_t) other.oldSymbol) - (cast(size_t) this.oldSymbol);
+		return (cast(ptrdiff_t) other.oldSymbol) - (cast(ptrdiff_t) this.oldSymbol);
 	}
 
 	DSymbol* oldSymbol;

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -135,55 +135,17 @@ enum SymbolQualifier : ubyte
  */
 struct DSymbol
 {
-public:
-
-	/**
-	 * Copying is disabled.
-	 */
+	// Copying is disabled
 	@disable this();
-
-	/// ditto
 	@disable this(this);
 
-	/// ditto
-	this(istring name) /+nothrow+/ /+@safe+/
-	{
-		this.name = name;
-	}
-
 	/**
 	 * Params:
 	 *     name = the symbol's name
 	 *     kind = the symbol's completion kind
+	 *     type = the resolved type of the symbol
 	 */
-	this(string name, CompletionKind kind) /+nothrow+/ /+@safe+/ /+@nogc+/
-	{
-		this.name = istring(name);
-		this.kind = kind;
-	}
-
-	/// ditto
-	this(istring name, CompletionKind kind) /+nothrow+/ /+@safe+/ /+@nogc+/
-	{
-		this.name = name;
-		this.kind = kind;
-	}
-
-	/**
-	 * Params:
-	 *     name = the symbol's name
-	 *     kind = the symbol's completion kind
-	 *     resolvedType = the resolved type of the symbol
-	 */
-	this(string name, CompletionKind kind, DSymbol* type)
-	{
-		this.name = istring(name);
-		this.kind = kind;
-		this.type = type;
-	}
-
-	/// ditto
-	this(istring name, CompletionKind kind, DSymbol* type)
+	this(istring name, CompletionKind kind = CompletionKind.dummy, DSymbol* type = null) nothrow @nogc @safe
 	{
 		this.name = name;
 		this.kind = kind;


### PR DESCRIPTION
When a thread terminates, global malloc-allocated things remain. Furthermore, destructors of thread-local objects aren't invoked either!

Tested on `serve-d` using Valgrind Massif.

I hope you won't mind that I've done some refactoring and other stuff in the meantime.