### PR TITLE
Fix public selective imports

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -518,7 +518,7 @@ final class FirstPass : ASTVisitor
 				SemanticSymbol* renameSymbol = allocateSemanticSymbol(
 					internString(single.rename.text), CompletionKind.aliasName,
 					modulePath);
-				renameSymbol.acSymbol.skipOver = protection.current != tok!"public";
+				renameSymbol.acSymbol.skipOver = protection.currentForImport != tok!"public";
 				renameSymbol.acSymbol.type = importSymbol.acSymbol;
 				renameSymbol.acSymbol.ownType = true;
 				renameSymbol.addChild(importSymbol, true);
@@ -562,7 +562,7 @@ final class FirstPass : ASTVisitor
 
 			importSymbol.acSymbol.qualifier = SymbolQualifier.selectiveImport;
 			importSymbol.typeLookups.insert(lookup);
-			importSymbol.acSymbol.skipOver = protection.current != tok!"public";
+			importSymbol.acSymbol.skipOver = protection.currentForImport != tok!"public";
 			currentSymbol.addChild(importSymbol, true);
 			currentScope.addSymbol(importSymbol.acSymbol, false);
 		}

--- a/src/dsymbol/conversion/second.d
+++ b/src/dsymbol/conversion/second.d
@@ -103,14 +103,14 @@ void resolveImport(DSymbol* acSymbol, ref UnrolledList!(TypeLookup*, Mallocator,
 	ref ModuleCache cache)
 in
 {
-	assert (acSymbol.kind == CompletionKind.importSymbol);
+	assert(acSymbol.kind == CompletionKind.importSymbol);
+	assert(acSymbol.symbolFile !is null);
 }
 body
 {
+	DSymbol* moduleSymbol = cache.cacheModule(acSymbol.symbolFile);
 	if (acSymbol.qualifier == SymbolQualifier.selectiveImport)
 	{
-		assert(acSymbol.symbolFile !is null);
-		DSymbol* moduleSymbol = cache.cacheModule(acSymbol.symbolFile);
 		if (moduleSymbol is null)
 		{
 		tryAgain:
@@ -128,7 +128,7 @@ body
 
 			istring symbolName = typeLookups.front.breadcrumbs.front;
 			DSymbol* selected = moduleSymbol.getFirstPartNamed(symbolName);
-			if (acSymbol is null)
+			if (selected is null)
 				goto tryAgain;
 			acSymbol.type = selected;
 			acSymbol.ownType = false;
@@ -144,8 +144,6 @@ body
 	}
 	else
 	{
-		assert(acSymbol.symbolFile !is null);
-		DSymbol* moduleSymbol = cache.cacheModule(acSymbol.symbolFile);
 		if (moduleSymbol is null)
 		{
 			DeferredSymbol* deferred = Mallocator.instance.make!DeferredSymbol(acSymbol);

--- a/src/dsymbol/scope_.d
+++ b/src/dsymbol/scope_.d
@@ -89,9 +89,8 @@ struct Scope
 		import std.algorithm.iteration : map;
 
 		auto s = getScopeByCursor(cursorPosition);
-
 		if (s is null)
-			return [];
+			return null;
 
 		UnrolledList!(DSymbol*) retVal;
 		Scope* sc = s;
@@ -112,7 +111,7 @@ struct Scope
 						foreach (i; item.ptr.type.opSlice())
 							retVal.insert(i);
 					}
-					else if (item.ptr !is null)
+					else
 						retVal.insert(item.ptr.type);
 				}
 				else


### PR DESCRIPTION
I guess it also fixes a weird bug when loads of unrelated symbols appeared in autocomplete lists. For example, I do `import std.stdio : File` in module A, then use A in module B, and suddenly `File` methods appear everywhere in B.