### PR TITLE
Implement completion for function literal parameters

### DIFF
--- a/src/dsymbol/builtin/names.d
+++ b/src/dsymbol/builtin/names.d
@@ -8,6 +8,8 @@ package istring[24] builtinTypeNames;
 /// Constants for buit-in or dummy symbol names
 istring FUNCTION_SYMBOL_NAME;
 /// ditto
+istring FUNCTION_LITERAL_SYMBOL_NAME;
+/// ditto
 istring IMPORT_SYMBOL_NAME;
 /// ditto
 istring ARRAY_SYMBOL_NAME;
@@ -135,6 +137,7 @@ static this()
 	builtinTypeNames[23] = internString("creal");
 
 	FUNCTION_SYMBOL_NAME = internString("function");
+	FUNCTION_LITERAL_SYMBOL_NAME = internString("*function-literal*");
 	IMPORT_SYMBOL_NAME = internString("import");
 	ARRAY_SYMBOL_NAME = internString("*arr*");
 	ARRAY_LITERAL_SYMBOL_NAME = internString("*arr-literal*");

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -720,6 +720,12 @@ final class FirstPass : ASTVisitor
 			withStatement.accept(this);
 	}
 
+	override void visit(const ArgumentList list)
+	{
+		auto visitor = scoped!(ArgumentListVisitor)(this);
+		visitor.visit(list);
+	}
+
 	alias visit = ASTVisitor.visit;
 
 	/// Module scope
@@ -1445,8 +1451,7 @@ class InitializerVisitor : ASTVisitor
 		lookup.breadcrumbs.insert(ARRAY_LITERAL_SYMBOL_NAME);
 	}
 
-	// Skip these
-	override void visit(const ArgumentList) {}
+	// Skip it
 	override void visit(const NewAnonClassExpression) {}
 
 	override void visit(const NewExpression ne)
@@ -1485,6 +1490,12 @@ class InitializerVisitor : ASTVisitor
 		ne.arguments = nace.constructorArguments;
 	}
 
+	override void visit(const ArgumentList list)
+	{
+		auto visitor = scoped!(ArgumentListVisitor)(fp);
+		visitor.visit(list);
+	}
+
 	override void visit(const Expression expression)
 	{
 		on = true;
@@ -1506,5 +1517,24 @@ class InitializerVisitor : ASTVisitor
 	TypeLookup* lookup;
 	bool on = false;
 	const bool appendForeach;
+	FirstPass fp;
+}
+
+class ArgumentListVisitor : ASTVisitor
+{
+	this(FirstPass fp)
+	{
+		assert(fp);
+		this.fp = fp;
+	}
+
+	alias visit = ASTVisitor.visit;
+
+	override void visit(const NewAnonClassExpression exp)
+	{
+		fp.visit(exp);
+	}
+
+private:
 	FirstPass fp;
 }

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -203,6 +203,35 @@ unittest
 {
 	ModuleCache cache = ModuleCache(theAllocator);
 
+	writeln("Running anon class tests...");
+	const sources = [
+		q{            auto a =   new class Object { int i;                };    },
+		q{            auto a =   new class Object { int i; void m() {   } };    },
+		q{            auto a = g(new class Object { int i;                });   },
+		q{            auto a = g(new class Object { int i; void m() {   } });   },
+		q{ void f() {            new class Object { int i;                };  } },
+		q{ void f() {            new class Object { int i; void m() {   } };  } },
+		q{ void f() {          g(new class Object { int i;                }); } },
+		q{ void f() {          g(new class Object { int i; void m() {   } }); } },
+		q{ void f() { auto a =   new class Object { int i;                };  } },
+		q{ void f() { auto a =   new class Object { int i; void m() {   } };  } },
+		q{ void f() { auto a = g(new class Object { int i;                }); } },
+		q{ void f() { auto a = g(new class Object { int i; void m() {   } }); } },
+	];
+	foreach (src; sources)
+	{
+		auto pair = generateAutocompleteTrees(src, cache);
+		auto a = pair.scope_.getFirstSymbolByNameAndCursor(istring("i"), 60);
+		assert(a, src);
+		assert(a.type, src);
+		assert(a.type.name == "int", src);
+	}
+}
+
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+
 	writeln("Running the deduction from index expr tests...");
 	{
 		auto source = q{struct S{} S[] s; auto b = s[i];};

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -105,6 +105,31 @@ unittest
 {
 	ModuleCache cache = ModuleCache(theAllocator);
 
+	writeln("Running function literal tests...");
+	const sources = [
+		q{            int a;   auto dg = {     };    },
+		q{ void f() { int a;   auto dg = {     };  } },
+		q{ auto f =              (int a) {     };    },
+		q{ auto f() { return     (int a) {     };  } },
+		q{ auto f() { return   g((int a) {     }); } },
+		q{ void f() {          g((int a) {     }); } },
+		q{ void f() { auto x =   (int a) {     };  } },
+		q{ void f() { auto x = g((int a) {     }); } },
+	];
+	foreach (src; sources)
+	{
+		auto pair = generateAutocompleteTrees(src, cache);
+		auto a = pair.scope_.getFirstSymbolByNameAndCursor(istring("a"), 35);
+		assert(a, src);
+		assert(a.type, src);
+		assert(a.type.name == "int", src);
+	}
+}
+
+unittest
+{
+	ModuleCache cache = ModuleCache(theAllocator);
+
 	writeln("Running struct constructor tests...");
 	auto source = q{ struct A {int a; struct B {bool b;} int c;} };
 	auto pair = generateAutocompleteTrees(source, cache);


### PR DESCRIPTION
It doesn't work for lambdas.

Argument list visitor handles cases like `auto a = g({...});` and `auto a = g(new class {...});` - symbols inside such blocks were invisible to dcd before this patch.