### PR TITLE
83x speed up `resolveImportLocation`

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -313,7 +313,7 @@ struct ModuleCache
 				string dotD = dotDi[0 .. $ - 1];
 				string withoutSuffix = dotDi[0 .. $ - 3];
 				if (existsAnd!isFile(dotD))
-					alternatives = dotD ~ alternatives;
+					return istring(dotD); // return early for exactly matching .d files
 				else if (existsAnd!isFile(dotDi))
 					alternatives ~= dotDi;
 				else if (existsAnd!isDir(withoutSuffix))

--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -460,8 +460,7 @@ private static bool getFileAttributesFast(R)(R name, uint* attributes)
 	version (Windows)
 	{
 		import std.internal.cstring : tempCStringW;
-		import core.sys.windows.winnt : INVALID_FILE_ATTRIBUTES,
-			FILE_ATTRIBUTE_DIRECTORY;
+		import core.sys.windows.winnt : INVALID_FILE_ATTRIBUTES;
 		import core.sys.windows.winbase : GetFileAttributesW;
 
 		auto namez = tempCStringW(name);
@@ -474,7 +473,7 @@ private static bool getFileAttributesFast(R)(R name, uint* attributes)
 	}
 	else version (Posix)
 	{
-		import core.sys.posix.sys.stat : stat, stat_t, S_IFMT, S_IFREG, S_IFDIR;
+		import core.sys.posix.sys.stat : stat, stat_t;
 		import std.internal.cstring : tempCString;
 
 		auto namez = tempCString(name);


### PR DESCRIPTION
* adds windows & posix specific file/dir checks with existence, drops previous try-catch based code which improves performance in debug mode like x50 for the `resolveImportLocation` function
* exact `.d` matches inside import paths now immediately return on the first import path instead of returning at the end of the function being equal to the path inside the last matching import path
* file import paths no longer perform any IO if the path wouldn't match anyway
* remove array allocations for alternatives, now uses simpler code which can also return early

This gives a big speed up improvement in DCD on Windows:

### Duration of first completion (ms)
|   | Old (Debug) | New (Debug) | Old (Release) | New (Release) |
|---:|------------:|------------:|--------------:|--------------:|
|   | 457792      | 5600        | 98314         | 3878          |
|   | 457994      | 5463        | 97429         | 3756          |
|   |             | 5471        | 98454         | 3805          |
| average | **457893**  | **5511**    | **98066**     | **3813**      |
| relative speed | **100%**    | **8308%**   | **100%**      | **2572%**     |

### Duration of later completions (ms)
|   | Old (Debug) | New (Debug) | Old (Release) | New (Release) |
|---:|------------:|------------:|--------------:|--------------:|
|   | 177         | 66          | 163           | 61            |
|   | 190         | 62          | 172           | 46            |
|   | 192         | 61          | 155           | 67            |
|        average | **186**     | **63**      | **163**       | **58**        |
| relative speed | **100%**    | **296%**    | **100%**      | **282%**      |


LDC 1.19.0
Target: x86_64-pc-windows-msvc
Host CPU: ivybridge
very little available RAM (<500 MB)
some SSD
