### PR TITLE
Fix the error message printed when a module cannot be found

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -478,7 +478,7 @@ final class FirstPass : ASTVisitor
 			istring modulePath = cache.resolveImportLocation(importPath);
 			if (modulePath is null)
 			{
-				warning("Could not resolve location of module '", importPath, "'");
+				warning("Could not resolve location of module '", importPath.data, "'");
 				continue;
 			}
 			SemanticSymbol* importSymbol = allocateSemanticSymbol(IMPORT_SYMBOL_NAME,


### PR DESCRIPTION
Print the string directly instead of the `istring`.

Old: `Could not resolve location of module 'immutable(istring)("gcc/builtins")'`
New: `Could not resolve location of module 'gcc/builtins'`