### PR TITLE
Fix several problems with symbol protection.

### DIFF
--- a/src/dsymbol/builtin/symbols.d
+++ b/src/dsymbol/builtin/symbols.d
@@ -294,15 +294,21 @@ private HashSet!(DSymbol*) symbolsMadeHere;
 
 private DSymbol* makeSymbol(string s, CompletionKind kind, DSymbol* type = null)
 {
+	import dparse.lexer : tok;
+
 	auto sym = rba.make!DSymbol(istring(s), kind, type);
 	sym.ownType = false;
+	sym.protection = tok!"public";
 	symbolsMadeHere.insert(sym);
 	return sym;
 }
 private DSymbol* makeSymbol(istring s, CompletionKind kind, DSymbol* type = null)
 {
+	import dparse.lexer : tok;
+
 	auto sym = rba.make!DSymbol(s, kind, type);
 	sym.ownType = false;
+	sym.protection = tok!"public";
 	symbolsMadeHere.insert(sym);
 	return sym;
 }

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -135,9 +135,8 @@ final class FirstPass : ASTVisitor
 	{
 		assert(dec);
 		pushSymbol(dec.name.text, CompletionKind.functionName, symbolFile,
-				dec.name.index, dec.returnType);
+				dec.name.index, dec.returnType, protection.current);
 		scope (exit) popSymbol();
-		currentSymbol.acSymbol.protection = protection.current;
 		currentSymbol.acSymbol.doc = makeDocumentation(dec.comment);
 
 		istring lastComment = this.lastComment;
@@ -387,6 +386,7 @@ final class FirstPass : ASTVisitor
 			auto objectImport = allocateSemanticSymbol(IMPORT_SYMBOL_NAME,
 				CompletionKind.importSymbol, objectLocation);
 			objectImport.acSymbol.skipOver = true;
+			objectImport.acSymbol.protection = protection.currentForImport;
 			currentSymbol.addChild(objectImport, true);
 			currentScope.addSymbol(objectImport.acSymbol, false);
 		}
@@ -453,6 +453,7 @@ final class FirstPass : ASTVisitor
 		thisSymbol.symbolFile = symbolFile;
 		thisSymbol.type = currentSymbol.acSymbol;
 		thisSymbol.ownType = false;
+		thisSymbol.protection = tok!"private";
 		currentScope.addSymbol(thisSymbol, false);
 
 		foreach (dec; structBody.declarations)
@@ -484,6 +485,7 @@ final class FirstPass : ASTVisitor
 			SemanticSymbol* importSymbol = allocateSemanticSymbol(IMPORT_SYMBOL_NAME,
 				CompletionKind.importSymbol, modulePath);
 			importSymbol.acSymbol.skipOver = protection.currentForImport != tok!"public";
+			importSymbol.acSymbol.protection = protection.currentForImport;
 			if (single.rename == tok!"")
 			{
 				size_t i = 0;
@@ -501,6 +503,7 @@ final class FirstPass : ASTVisitor
 						if (s.length == 0)
 						{
 							currentImportSymbol = symbolAllocator.make!DSymbol(ip, kind);
+							currentImportSymbol.protection = protection.currentForImport;
 							currentScope.addSymbol(currentImportSymbol, true);
 							if (last)
 							{
@@ -518,6 +521,7 @@ final class FirstPass : ASTVisitor
 						if (s.length == 0)
 						{
 							auto sym = symbolAllocator.make!DSymbol(ip, kind);
+							sym.protection = protection.currentForImport;
 							currentImportSymbol.addChild(sym, true);
 							currentImportSymbol = sym;
 							if (last)
@@ -540,6 +544,7 @@ final class FirstPass : ASTVisitor
 				SemanticSymbol* renameSymbol = allocateSemanticSymbol(
 					internString(single.rename.text), CompletionKind.aliasName,
 					modulePath);
+				renameSymbol.acSymbol.protection = protection.currentForImport;
 				renameSymbol.acSymbol.skipOver = protection.currentForImport != tok!"public";
 				renameSymbol.acSymbol.type = importSymbol.acSymbol;
 				renameSymbol.acSymbol.ownType = true;
@@ -557,7 +562,7 @@ final class FirstPass : ASTVisitor
 		istring modulePath = cache.resolveImportLocation(chain);
 		if (modulePath is null)
 		{
-			warning("Could not resolve location of module '", chain, "'");
+			warning("Could not resolve location of module '", chain.data, "'");
 			return;
 		}
 
@@ -585,6 +590,7 @@ final class FirstPass : ASTVisitor
 			importSymbol.acSymbol.qualifier = SymbolQualifier.selectiveImport;
 			importSymbol.typeLookups.insert(lookup);
 			importSymbol.acSymbol.skipOver = protection.currentForImport != tok!"public";
+			importSymbol.acSymbol.protection = protection.currentForImport;
 			currentSymbol.addChild(importSymbol, true);
 			currentScope.addSymbol(importSymbol.acSymbol, false);
 		}
@@ -848,7 +854,7 @@ private:
 	}
 
 	void pushSymbol(string name, CompletionKind kind, istring symbolFile,
-		size_t location = 0, const Type type = null)
+		size_t location = 0, const Type type = null, const IdType protection = tok!"public")
 	{
 		SemanticSymbol* symbol = allocateSemanticSymbol(name, kind, symbolFile,
 			location);
@@ -884,14 +890,13 @@ private:
 			dec.accept(this);
 			return;
 		}
-		pushSymbol(dec.name.text, kind, symbolFile, dec.name.index);
+		pushSymbol(dec.name.text, kind, symbolFile, dec.name.index, null, protection.current);
 		scope(exit) popSymbol();
 
 		if (kind == CompletionKind.className)
 			currentSymbol.acSymbol.addChildren(classSymbols[], false);
 		else
 			currentSymbol.acSymbol.addChildren(aggregateSymbols[], false);
-		currentSymbol.acSymbol.protection = protection.current;
 		currentSymbol.acSymbol.doc = makeDocumentation(dec.comment);
 
 		istring lastComment = this.lastComment;
@@ -1106,7 +1111,7 @@ private:
 	}
 
 	SemanticSymbol* allocateSemanticSymbol(string name, CompletionKind kind,
-		istring symbolFile, size_t location = 0)
+		istring symbolFile, size_t location = 0, IdType protection = tok!"public")
 	in
 	{
 		assert (symbolAllocator !is null);
@@ -1116,6 +1121,7 @@ private:
 		DSymbol* acSymbol = make!DSymbol(symbolAllocator, istring(name), kind);
 		acSymbol.location = location;
 		acSymbol.symbolFile = symbolFile;
+		acSymbol.protection = protection;
 		symbolsAllocated++;
 		return semanticAllocator.make!SemanticSymbol(acSymbol);
 	}
@@ -1235,17 +1241,18 @@ struct ProtectionStack
 
 	IdType currentForImport() const
 	{
-		return stack.empty ? tok!"default" : current();
+		return stack.empty ? tok!"public" : current();
 	}
 
 	IdType current() const
+	out(t) { assert(isProtection(t), str(t)); }
+	do
 	{
 		import std.algorithm.iteration : filter;
 		import std.range : choose, only;
 
-		IdType retVal;
-		foreach (t; choose(stack.empty, only(tok!"public"), stack[]).filter!(
-				a => a != tok!"{" && a != tok!":"))
+		IdType retVal = tok!"public";
+		foreach (t; stack[].filter!(a => a != tok!"{" && a != tok!":"))
 			retVal = cast(IdType) t;
 		return retVal;
 	}
@@ -1274,7 +1281,7 @@ struct ProtectionStack
 
 	void beginLocal(const IdType t)
 	{
-		assert (t != tok!"", "DERP!");
+		assert(isProtection(t), str(t));
 		stack.insertBack(t);
 	}
 

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -504,6 +504,7 @@ final class FirstPass : ASTVisitor
 						{
 							currentImportSymbol = symbolAllocator.make!DSymbol(ip, kind);
 							currentImportSymbol.protection = protection.currentForImport;
+							currentImportSymbol.skipOver = protection.currentForImport != tok!"public";
 							currentScope.addSymbol(currentImportSymbol, true);
 							if (last)
 							{
@@ -522,6 +523,7 @@ final class FirstPass : ASTVisitor
 						{
 							auto sym = symbolAllocator.make!DSymbol(ip, kind);
 							sym.protection = protection.currentForImport;
+							sym.skipOver = protection.currentForImport != tok!"public";
 							currentImportSymbol.addChild(sym, true);
 							currentImportSymbol = sym;
 							if (last)
@@ -1241,7 +1243,8 @@ struct ProtectionStack
 
 	IdType currentForImport() const
 	{
-		return stack.empty ? tok!"public" : current();
+		// Imports are private unless specified otherwise.
+		return stack.empty ? tok!"private" : current();
 	}
 
 	IdType current() const

--- a/src/dsymbol/conversion/second.d
+++ b/src/dsymbol/conversion/second.d
@@ -336,6 +336,7 @@ void resolveInheritance(DSymbol* symbol, ref UnrolledList!(TypeLookup*, Mallocat
 
 		DSymbol* imp = cache.symbolAllocator.make!DSymbol(IMPORT_SYMBOL_NAME,
 			CompletionKind.importSymbol, baseClass);
+		imp.protection = tok!"public";
 		symbol.addChild(imp, true);
 		symbolScope.addSymbol(imp, false);
 		if (baseClass.kind == CompletionKind.className)
@@ -360,6 +361,7 @@ void resolveAliasThis(DSymbol* symbol,
 			continue;
 		DSymbol* s = cache.symbolAllocator.make!DSymbol(IMPORT_SYMBOL_NAME,
 			CompletionKind.importSymbol, parts[0].type);
+		s.protection = tok!"public";
 		symbol.addChild(s, true);
 		auto symbolScope = moduleScope.getScopeByCursor(s.location);
 		if (symbolScope !is null)
@@ -397,6 +399,7 @@ void resolveMixinTemplates(DSymbol* symbol,
 			auto i = cache.symbolAllocator.make!DSymbol(IMPORT_SYMBOL_NAME,
 				CompletionKind.importSymbol, currentSymbol);
 			i.ownType = false;
+			i.protection = tok!"public";
 			symbol.addChild(i, true);
 		}
 	}

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -299,6 +299,7 @@ struct DSymbol
 	void addChild(DSymbol* symbol, bool owns)
 	{
 		assert(symbol !is null);
+		assert(isProtection(symbol.protection));
 		parts.insert(SymbolOwnership(symbol, owns));
 	}
 
@@ -307,6 +308,7 @@ struct DSymbol
 		foreach (symbol; symbols)
 		{
 			assert(symbol !is null);
+			assert(isProtection(symbol.protection));
 			parts.insert(SymbolOwnership(symbol, owns));
 		}
 	}
@@ -316,6 +318,7 @@ struct DSymbol
 		foreach (symbol; symbols)
 		{
 			assert(symbol !is null);
+			assert(isProtection(symbol.protection));
 			parts.insert(SymbolOwnership(symbol, owns));
 		}
 	}


### PR DESCRIPTION
There were several problems with protection being set on symbols. An example of this is https://github.com/dlang-community/DCD/issues/620.

This adds a few extra asserts, and prevents a lot of cases of symbols being created without any protection being set.