### PR TITLE
Fix parsing bugs that caused symbol visibility to be incorrect.

### DIFF
--- a/src/dsymbol/conversion/package.d
+++ b/src/dsymbol/conversion/package.d
@@ -142,7 +142,7 @@ class SimpleParser : Parser
 		expect(tok!"unittest");
 		if (currentIs(tok!"{"))
 			skipBraces();
-		return new Unittest;
+		return allocator.make!Unittest;
 	}
 
 	override MissingFunctionBody parseMissingFunctionBody()


### PR DESCRIPTION
This fixes a few bugs in the specialized parser that is run on code that is imported (i.e. the function bodies and unit test bodies are skipped). Returning `null` from these functions caused the parser to go into error recovery mode and skip ahead to the nearest semicolon or closing brace. This causes dsymbol to actually fail to correctly parse well-formed code, leading to problems like https://github.com/dlang-community/DCD/issues/620.

In addition to not returning `null` from the `unittest` parser, this change also fixes a problem where some forms of functions with contracts were skipped incorrectly, which also caused them to be missing in autocomplete lists in DCD. There are test cases in the linked DCD draft pull request. dsymbol's unit test coverage is pretty bad and I don't intend to fix that with this pull.

Related:
* https://github.com/dlang-community/DCD/pull/622
* https://github.com/dlang-community/dsymbol/pull/153