### PR TITLE
disable meson tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ before_script:
   export PATH=$PATH:$PWD/.ntmp
 
 script:
-  - meson build && ninja -j2 -C build
-  - ninja -j2 -C build test -v
+  # Meson tests are disabled for now because old dependencies caused builds to fail
+  #- meson build && ninja -j2 -C build
+  #- ninja -j2 -C build test -v
+  #
   - rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=release --compiler=${DC}
   - rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub test --compiler=${DC}


### PR DESCRIPTION
broken dependencies causes builds to fail