### PR TITLE
Create callTip for symbols with breadcrumbs

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -1148,9 +1148,7 @@ private:
 
 		foreach (suffix; type.typeSuffixes)
 		{
-			if (suffix.star != tok!"")
-				continue;
-			else if (suffix.type)
+			if (suffix.type)
 				lookup.breadcrumbs.insert(ASSOC_ARRAY_SYMBOL_NAME);
 			else if (suffix.array)
 				lookup.breadcrumbs.insert(ARRAY_SYMBOL_NAME);

--- a/src/dsymbol/conversion/second.d
+++ b/src/dsymbol/conversion/second.d
@@ -174,20 +174,23 @@ do
 	DSymbol* lastSuffix;
 
 	// Create symbols for the type suffixes such as array and
-	// associative array
+	// associative array and pointers
+
+	// If breadcrumbs, then we need to construct the callTip
+	string callTip;
+	foreach (b; lookup.breadcrumbs[])
+	{
+		callTip ~= b;
+	}
+	
 	while (!lookup.breadcrumbs.empty)
 	{
 		auto back = lookup.breadcrumbs.back;
 		immutable bool isArr = back == ARRAY_SYMBOL_NAME;
 		immutable bool isAssoc = back == ASSOC_ARRAY_SYMBOL_NAME;
 		immutable bool isFunction = back == FUNCTION_SYMBOL_NAME;
-		if (back == POINTER_SYMBOL_NAME)
-		{
-			lastSuffix.isPointer = true;
-			lookup.breadcrumbs.popBack();
-			continue;
-		}
-		if (!isArr && !isAssoc && !isFunction)
+		immutable bool isPointer = back == POINTER_SYMBOL_NAME;
+		if (!isArr && !isAssoc && !isFunction && !isPointer)
 			break;
 		immutable qualifier = isAssoc ? SymbolQualifier.assocArray :
 			(isFunction ? SymbolQualifier.func : SymbolQualifier.array);
@@ -200,7 +203,11 @@ do
 			lastSuffix.callTip = lookup.breadcrumbs.back();
 		}
 		else
+		{
 			lastSuffix.addChildren(isArr ? arraySymbols[] : assocArraySymbols[], false);
+			lastSuffix.callTip = istring(callTip);
+			lastSuffix.isPointer = isPointer;
+		}
 
 		if (suffix is null)
 			suffix = lastSuffix;


### PR DESCRIPTION
I was tired of DCD hiding the fact that my variable was a pointer, it only showed the Type, wich sucks

So i went ahead and fixed that, finally..

And this also solve cases where type was missing from arrays

# Pointer

Before: 
![image](https://user-images.githubusercontent.com/18348637/135948681-8f6d1297-519f-4365-aa64-4532b39277e8.png)

After:
![image](https://user-images.githubusercontent.com/18348637/135948506-59f6ec5f-83b4-4e7b-9c3e-668ab49ce426.png)

# Array

Before: 
![image](https://user-images.githubusercontent.com/18348637/135948707-07283157-572f-4f78-a103-774927393714.png)

After:
![image](https://user-images.githubusercontent.com/18348637/135948528-783ab923-2ed8-4e96-844b-ad47f008f097.png)