### PR TITLE
Rename SemanticAllocator to ASTAllocator

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -48,7 +48,7 @@ import std.file;
 import std.experimental.lexer;
 import std.path;
 
-alias SemanticAllocator = AllocatorList!(n => Region!Mallocator(1024 * 128), Mallocator);
+alias ASTAllocator = AllocatorList!(n => Region!Mallocator(1024 * 128), Mallocator);
 
 /**
  * Returns: true if a file exists at the given path.
@@ -196,7 +196,7 @@ struct ModuleCache
 
 		CacheEntry* newEntry = CacheAllocator.instance.make!CacheEntry();
 
-		scope semanticAllocator = new SemanticAllocator();
+		scope semanticAllocator = new ASTAllocator();
 		import dparse.rollback_allocator:RollbackAllocator;
 		RollbackAllocator parseAllocator;
 		Module m = parseModuleSimple(tokens[], cachedLocation, &parseAllocator);


### PR DESCRIPTION
This reverts accidental rename of this public symbol at https://github.com/dlang-community/dsymbol/commit/b090b70c4775cd5ba8865d8a450b1fbef84376b4#diff-65f2448b99faadbee0fa35083cd6ed8308a763082ca322f3ce2d6fb8908041cdR51.

Ready for merging and tagging, @WebFreak001.