### PR TITLE
Properly update symbol dependencies when updating a cached module

### DIFF
--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -463,13 +463,29 @@ alias UpdatePairCollection = TTree!(UpdatePair, UpdatePairCollectionAllocator, f
 void generateUpdatePairs(DSymbol* oldSymbol, DSymbol* newSymbol, ref UpdatePairCollection results)
 {
 	results.insert(UpdatePair(oldSymbol, newSymbol));
-	foreach (part; oldSymbol.parts[])
+	foreach (part; oldSymbol.opSlice())
 	{
-		auto temp = DSymbol(oldSymbol.name);
-		auto r = newSymbol.parts.equalRange(SymbolOwnership(&temp));
-		if (r.empty)
-			continue;
-		generateUpdatePairs(part, r.front, results);
+		bool has = false;
+		DSymbol* r = null;
+		foreach(newPart; newSymbol.opSlice())
+		{
+			if(part == newPart)
+			{
+				has = true;
+				r = newPart;
+				break;
+			}
+
+			if (part.name == newPart.name && part.location == newPart.location)
+			{
+				has = true;
+				r = newPart;
+				break;
+			}
+		}
+		if (!has) continue;
+
+		generateUpdatePairs(part, r, results);
 	}
 }
 


### PR DESCRIPTION
Solves this particulate case


```d
module a;

import b;

b.data // if we edit the module C, then the modulecache doesn't properly propagate the changes to module c and its dependents because of the ownership check
```

```d
module b;
import c;
StructFromC data;
```

```d
module c;

struct StructFromC
{}
```