### PR TITLE
update libdparse to fix issue in DCD

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,7 @@
 	"targetPath": "build",
 	"targetType": "library",
 	"dependencies": {
-		"libdparse": ">=0.19.3 <0.20.0",
+		"libdparse": ">=0.20.0 <0.21.0",
 		"emsi_containers": "~>0.8.0"
 	}
 }


### PR DESCRIPTION
this should hopefully no longer be needed if we integrate dsymbol into DCD

the update in libdparse removed the stdx-allocators dependency, which we removed in dsymbol with the latest tag as well.