### PR TITLE
make function symbols store function parameters, needed for UFCS.

### DIFF
--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -973,6 +973,7 @@ private:
 		processTemplateParameters(symbol, templateParameters);
 		if (includeParameterSymbols && parameters !is null)
 		{
+			currentSymbol.acSymbol.functionArguments.reserve(parameters.parameters.length);
 			foreach (const Parameter p; parameters.parameters)
 			{
 				SemanticSymbol* parameter = allocateSemanticSymbol(

--- a/src/dsymbol/conversion/first.d
+++ b/src/dsymbol/conversion/first.d
@@ -152,6 +152,7 @@ final class FirstPass : ASTVisitor
 			pushFunctionScope(dec.functionBody, semanticAllocator,
 					dec.name.index + dec.name.text.length);
 			scope (exit) popScope();
+            includeParameterSymbols = true;
 			processParameters(currentSymbol, dec.returnType,
 					currentSymbol.acSymbol.name, dec.parameters, dec.templateParameters);
 			dec.functionBody.accept(this);
@@ -981,6 +982,9 @@ private:
 					addTypeToLookups(parameter.typeLookups, p.type);
 				parameter.parent = currentSymbol;
 				currentSymbol.acSymbol.argNames.insert(parameter.acSymbol.name);
+
+                currentSymbol.acSymbol.functionArguments ~= parameter.acSymbol;
+
 				currentSymbol.addChild(parameter, true);
 				currentScope.addSymbol(parameter.acSymbol, false);
 			}

--- a/src/dsymbol/conversion/package.d
+++ b/src/dsymbol/conversion/package.d
@@ -43,7 +43,7 @@ ScopeSymbolPair generateAutocompleteTrees(const(Token)[] tokens,
 		parseAllocator, cursorPosition);
 
 	scope first = new FirstPass(m, internString("stdin"), symbolAllocator,
-		symbolAllocator, true, &cache);
+		symbolAllocator, &cache);
 	first.run();
 
 	secondPass(first.rootSymbol, first.moduleScope, cache);

--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -203,7 +203,7 @@ struct ModuleCache
 
 		assert (!symbolAllocator.isNull);
 		scope first = new FirstPass(m, cachedLocation, symbolAllocator,
-									semanticAllocator.allocatorObject, false, &this, newEntry);
+									semanticAllocator.allocatorObject, &this, newEntry);
 		first.run();
 
 		secondPass(first.rootSymbol, first.moduleScope, this);

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -375,9 +375,15 @@ struct DSymbol
 	/**
 	 * Names of function arguments
 	 */
+	// TODO: remove since we have function arguments
 	UnrolledList!(istring) argNames;
 
 	private uint _location;
+
+    /**
+     * Function argument symbols
+	 */
+	DSymbol*[] functionArguments;
 
 	/**
 	 * DSymbol location

--- a/src/dsymbol/symbol.d
+++ b/src/dsymbol/symbol.d
@@ -380,10 +380,10 @@ struct DSymbol
 
 	private uint _location;
 
-    /**
-     * Function argument symbols
+	/**
+	 * Function parameter symbols
 	 */
-	DSymbol*[] functionArguments;
+	DSymbol*[] functionParameters;
 
 	/**
 	 * DSymbol location

--- a/src/dsymbol/tests.d
+++ b/src/dsymbol/tests.d
@@ -538,7 +538,7 @@ ScopeSymbolPair generateAutocompleteTrees(string source, string filename, ref Mo
 	Module m = parseModule(tokens, filename, &rba);
 
 	scope first = new FirstPass(m, internString(filename),
-			theAllocator, theAllocator, true, &cache);
+			theAllocator, theAllocator, &cache);
 	first.run();
 
 	secondPass(first.rootSymbol, first.moduleScope, cache);


### PR DESCRIPTION
To not rely on callTips and properly support UFCS, we need functions to store their applicable argument symbols, this PR adds does this.